### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/examples/citizen.cc
+++ b/examples/citizen.cc
@@ -21,10 +21,11 @@
  */
  
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 #include <boost/format.hpp>
-#include <memory>
+
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 

--- a/examples/citizen.cc
+++ b/examples/citizen.cc
@@ -52,7 +52,7 @@ public:
     explicit MyClass(char const* typeName = 0);
     int addOne();
 private:
-    boost::scoped_ptr<int> _ptr;         // no need to track this alloc
+    std::unique_ptr<int> _ptr;         // no need to track this alloc
 };
 
 MyClass::MyClass(char const* /* typeName */) :
@@ -68,7 +68,7 @@ int MyClass::addOne() {
 using namespace lsst::daf::base;
 
 MyClass *foo() {
-    boost::scoped_ptr<Shoe> x(new Shoe(1));
+    std::unique_ptr<Shoe> x(new Shoe(1));
     MyClass *myInstance = new MyClass();
 
     std::cout << "In foo\n";
@@ -102,14 +102,14 @@ int main() {
     // x isn't going to be deleted until main exists, so don't list as a leak
     x.markPersistent();
     
-    boost::scoped_ptr<Shoe> y(new Shoe);
-    boost::scoped_ptr<Shoe> z(new Shoe(10));
+    std::unique_ptr<Shoe> y(new Shoe);
+    std::unique_ptr<Shoe> z(new Shoe(10));
     
     MyClass *mine = ::foo();
 
     std::cout << boost::format("In main (%d objects)\n") % Citizen::census(0);
 
-    boost::scoped_ptr<std::vector<Citizen const*> const> leaks(Citizen::census());
+    std::unique_ptr<std::vector<Citizen const*> const> leaks(Citizen::census());
     for (std::vector<Citizen const*>::const_iterator cur = leaks->begin();
          cur != leaks->end(); cur++) {
         std::cerr << boost::format("    %s\n") % (*cur)->repr();

--- a/examples/citizen.cc
+++ b/examples/citizen.cc
@@ -24,8 +24,7 @@
 #include <stdexcept>
 
 #include <boost/format.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 

--- a/include/lsst/daf/base/Persistable.h
+++ b/include/lsst/daf/base/Persistable.h
@@ -47,7 +47,7 @@
   * @ingroup daf_base
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <typeinfo>
 
 namespace lsst {
@@ -73,7 +73,7 @@ namespace base {
 
 class Persistable {
 public:
-    typedef boost::shared_ptr<Persistable> Ptr;
+    typedef std::shared_ptr<Persistable> Ptr;
 
     Persistable(void);
     virtual ~Persistable(void);

--- a/include/lsst/daf/base/PropertyList.h
+++ b/include/lsst/daf/base/PropertyList.h
@@ -53,14 +53,15 @@
   * @ingroup daf_base
   */
 
-#include <unordered_map>
 #include <list>
+#include <memory>
 #include <string>
 #include <typeinfo>
+#include <unordered_map>
 #include <vector>
 
 #include "boost/any.hpp"
-#include <memory>
+
 #include "lsst/daf/base/PropertySet.h"
 
 namespace lsst {

--- a/include/lsst/daf/base/PropertyList.h
+++ b/include/lsst/daf/base/PropertyList.h
@@ -60,7 +60,7 @@
 #include <vector>
 
 #include "boost/any.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/daf/base/PropertySet.h"
 
 namespace lsst {
@@ -81,8 +81,8 @@ namespace base {
 class PropertyList : public PropertySet {
 public:
 // Typedefs
-    typedef boost::shared_ptr<PropertyList> Ptr;
-    typedef boost::shared_ptr<PropertyList const> ConstPtr;
+    typedef std::shared_ptr<PropertyList> Ptr;
+    typedef std::shared_ptr<PropertyList const> ConstPtr;
 
 // Constructors
     PropertyList(void);
@@ -201,7 +201,7 @@ private:
     typedef std::unordered_map<std::string, std::string> CommentMap;
 
     virtual void _set(std::string const& name,
-                      boost::shared_ptr< std::vector<boost::any> > vp);
+                      std::shared_ptr< std::vector<boost::any> > vp);
     virtual void _moveToEnd(std::string const& name);
     virtual void _commentOrderFix(
         std::string const& name, std::string const& comment, bool inPlace);

--- a/include/lsst/daf/base/PropertySet.h
+++ b/include/lsst/daf/base/PropertySet.h
@@ -59,7 +59,7 @@
 
 #include "boost/any.hpp"
 #include "boost/noncopyable.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/daf/base/Persistable.h"
 #include "lsst/pex/exceptions.h"
@@ -87,8 +87,8 @@ class PropertySet :
     {
 public:
 // Typedefs
-    typedef boost::shared_ptr<PropertySet> Ptr;
-    typedef boost::shared_ptr<PropertySet const> ConstPtr;
+    typedef std::shared_ptr<PropertySet> Ptr;
+    typedef std::shared_ptr<PropertySet const> ConstPtr;
 
 // Constructors
     explicit PropertySet(bool flat=false);
@@ -155,21 +155,21 @@ public:
 
 protected:
     virtual void _set(std::string const& name,
-                      boost::shared_ptr< std::vector<boost::any> > vp);
+                      std::shared_ptr< std::vector<boost::any> > vp);
     virtual void _add(std::string const& name,
-                      boost::shared_ptr< std::vector<boost::any> > vp);
+                      std::shared_ptr< std::vector<boost::any> > vp);
     virtual std::string _format(std::string const& name) const;
 
 private:
     LSST_PERSIST_FORMATTER(lsst::daf::persistence::PropertySetFormatter)
 
     typedef std::unordered_map<std::string,
-            boost::shared_ptr< std::vector<boost::any> > > AnyMap;
+            std::shared_ptr< std::vector<boost::any> > > AnyMap;
 
     AnyMap::iterator _find(std::string const& name);
     AnyMap::const_iterator _find(std::string const& name) const;
     virtual void _findOrInsert(std::string const& name,
-                      boost::shared_ptr< std::vector<boost::any> > vp);
+                      std::shared_ptr< std::vector<boost::any> > vp);
     void _cycleCheckPtrVec(std::vector<Ptr> const& v, std::string const& name);
     void _cycleCheckAnyVec(std::vector<boost::any> const& v,
                           std::string const& name);

--- a/include/lsst/daf/base/PropertySet.h
+++ b/include/lsst/daf/base/PropertySet.h
@@ -52,14 +52,15 @@
   * @ingroup daf_base
   */
 
-#include <unordered_map>
+#include <memory>
 #include <string>
 #include <typeinfo>
+#include <unordered_map>
 #include <vector>
 
 #include "boost/any.hpp"
 #include "boost/noncopyable.hpp"
-#include <memory>
+
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/daf/base/Persistable.h"
 #include "lsst/pex/exceptions.h"

--- a/python/lsst/daf/base/baseLib.i
+++ b/python/lsst/daf/base/baseLib.i
@@ -128,7 +128,7 @@ PropertySetAddType(float, Float)
 PropertySetAddType(double, Double)
 PropertySetAddType(std::string, String)
 PropertySetAddType(lsst::daf::base::DateTime, DateTime)
-PropertySetAddType(boost::shared_ptr<lsst::daf::base::PropertySet>, PropertySet)
+PropertySetAddType(std::shared_ptr<lsst::daf::base::PropertySet>, PropertySet)
 
 %pythoncode %{
 def _propertyContainerElementTypeName(container, name):

--- a/python/lsst/daf/base/persistenceMacros.i
+++ b/python/lsst/daf/base/persistenceMacros.i
@@ -23,12 +23,12 @@
  */
  
 
-// Provides dynamic down casts from boost::shared_ptr<lsst::daf::base::Persistable>
+// Provides dynamic down casts from std::shared_ptr<lsst::daf::base::Persistable>
 %define %lsst_persistable(CppType...)
 
     %extend CppType {
-        static boost::shared_ptr<CppType > swigConvert(boost::shared_ptr<lsst::daf::base::Persistable> const & ptr) {
-            return boost::dynamic_pointer_cast<CppType >(ptr);
+        static std::shared_ptr<CppType > swigConvert(std::shared_ptr<lsst::daf::base::Persistable> const & ptr) {
+            return std::dynamic_pointer_cast<CppType >(ptr);
         }
     }
 

--- a/src/Citizen.cc
+++ b/src/Citizen.cc
@@ -26,8 +26,7 @@
 //! \brief Implementation of Citizen
 
 #include <iostream>
-#include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>         // should use std::unique_ptr from C++11 when available
+#include <memory>
 #include <boost/format.hpp>
 #include <ctype.h>
 #include <cerrno>

--- a/src/Citizen.cc
+++ b/src/Citizen.cc
@@ -25,11 +25,13 @@
 //! \file
 //! \brief Implementation of Citizen
 
+#include <ctype.h>
+
+#include <cerrno>
 #include <iostream>
 #include <memory>
+
 #include <boost/format.hpp>
-#include <ctype.h>
-#include <cerrno>
 
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/pex/exceptions.h"

--- a/src/Citizen.cc
+++ b/src/Citizen.cc
@@ -292,7 +292,7 @@ void dafBase::Citizen::census(
     ) {
     ReadGuard guard(citizenLock);
 
-    boost::scoped_ptr<std::vector<Citizen const*> const> leaks(Citizen::census());
+    std::unique_ptr<std::vector<Citizen const*> const> leaks(Citizen::census());
 
     for (std::vector<Citizen const *>::const_iterator citizen = leaks->begin(), end = leaks->end();
          citizen != end; ++citizen) {
@@ -314,7 +314,7 @@ bool cmpId(dafBase::Citizen const *a, dafBase::Citizen const *b)
 //! Return a (newly allocated) std::vector of active Citizens sorted by ID
 //
 //! You are responsible for deleting it; or you can say
-//!    boost::scoped_ptr<std::vector<Citizen const*> const>
+//!    std::unique_ptr<std::vector<Citizen const*> const>
 //!        leaks(Citizen::census());
 //! and not bother (that becomes std::unique_ptr in C++11)
 //

--- a/src/PropertyList.cc
+++ b/src/PropertyList.cc
@@ -196,7 +196,7 @@ void PropertyList::set(
 void PropertyList::set(
     std::string const& name, PropertySet::Ptr const& value,
     bool inPlace) {
-    Ptr pl = boost::dynamic_pointer_cast<PropertyList, PropertySet>(value);
+    Ptr pl = std::dynamic_pointer_cast<PropertyList, PropertySet>(value);
     PropertySet::set(name, value);
     _comments.erase(name);
     _order.remove(name);
@@ -415,7 +415,7 @@ void PropertyList::copy(
     std::string const& name, bool inPlace) {
     PropertySet::copy(dest, source, name);
     ConstPtr pl =
-        boost::dynamic_pointer_cast<PropertyList const, PropertySet const>(
+        std::dynamic_pointer_cast<PropertyList const, PropertySet const>(
             source);
     if (pl) {
         _comments[name] = pl->_comments.find(name)->second;
@@ -437,7 +437,7 @@ void PropertyList::copy(
 void PropertyList::combine(PropertySet::ConstPtr source,
                                     bool inPlace) {
     ConstPtr pl =
-        boost::dynamic_pointer_cast<PropertyList const, PropertySet const>(
+        std::dynamic_pointer_cast<PropertyList const, PropertySet const>(
             source);
     std::list<std::string> newOrder;
     if (pl) {
@@ -479,7 +479,7 @@ void PropertyList::remove(std::string const& name) {
 ///////////////////////////////////////////////////////////////////////////////
 
 void PropertyList::_set(std::string const& name,
-          boost::shared_ptr< std::vector<boost::any> > vp) {
+          std::shared_ptr< std::vector<boost::any> > vp) {
     PropertySet::_set(name, vp);
     if (_comments.find(name) == _comments.end()) {
         _comments.insert(std::make_pair(name, std::string()));

--- a/src/PropertySet.cc
+++ b/src/PropertySet.cc
@@ -81,7 +81,7 @@ dafBase::PropertySet::Ptr dafBase::PropertySet::deepCopy(void) const {
                 }
             }
         } else {
-            boost::shared_ptr< vector<boost::any> > vp(
+            std::shared_ptr< vector<boost::any> > vp(
                 new vector<boost::any>(*(i->second)));
             n->_map[i->first] = vp;
         }
@@ -479,7 +479,7 @@ std::string dafBase::PropertySet::toString(bool topLevelOnly,
     vector<string> nv = names();
     sort(nv.begin(), nv.end());
     for (vector<string>::const_iterator i = nv.begin(); i != nv.end(); ++i) {
-        boost::shared_ptr< vector<boost::any> > vp = _map.find(*i)->second;
+        std::shared_ptr< vector<boost::any> > vp = _map.find(*i)->second;
         type_info const& t = vp->back().type();
         if (t == typeid(Ptr)) {
             s << indent << *i << " = ";
@@ -509,7 +509,7 @@ std::string dafBase::PropertySet::_format(std::string const& name) const {
     s << std::showpoint; // Always show a decimal point for floats
     AnyMap::const_iterator j = _map.find(name);
     s << j->first << " = ";
-    boost::shared_ptr< vector<boost::any> > vp = j->second;
+    std::shared_ptr< vector<boost::any> > vp = j->second;
     if (vp->size() > 1) {
         s << "[ ";
     }
@@ -579,7 +579,7 @@ std::string dafBase::PropertySet::_format(std::string const& name) const {
   */
 template <typename T>
 void dafBase::PropertySet::set(std::string const& name, T const& value) {
-    boost::shared_ptr< vector<boost::any> > vp(new vector<boost::any>);
+    std::shared_ptr< vector<boost::any> > vp(new vector<boost::any>);
     vp->push_back(value);
     _set(name, vp);
 }
@@ -594,7 +594,7 @@ template <typename T>
 void dafBase::PropertySet::set(std::string const& name,
                                vector<T> const& value) {
     if (value.empty()) return;
-    boost::shared_ptr< vector<boost::any> > vp(new vector<boost::any>);
+    std::shared_ptr< vector<boost::any> > vp(new vector<boost::any>);
     vp->insert(vp->end(), value.begin(), value.end());
     _set(name, vp);
 }
@@ -722,7 +722,7 @@ void dafBase::PropertySet::copy(std::string const& dest,
                           name + " not in source");
     }
     remove(dest);
-    boost::shared_ptr< vector<boost::any> > vp(
+    std::shared_ptr< vector<boost::any> > vp(
         new vector<boost::any>(*(sj->second)));
     _set(dest, vp);
 }
@@ -835,7 +835,7 @@ dafBase::PropertySet::_find(std::string const& name) const {
   * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
   */
 void dafBase::PropertySet::_set(
-    std::string const& name, boost::shared_ptr< std::vector<boost::any> > vp) {
+    std::string const& name, std::shared_ptr< std::vector<boost::any> > vp) {
     _findOrInsert(name, vp);
 }
 
@@ -846,7 +846,7 @@ void dafBase::PropertySet::_set(
   * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
   */
 void dafBase::PropertySet::_add(
-    std::string const& name, boost::shared_ptr< std::vector<boost::any> > vp) {
+    std::string const& name, std::shared_ptr< std::vector<boost::any> > vp) {
 
     AnyMap::const_iterator dp = _find(name);
     if (dp == _map.end()) {
@@ -872,7 +872,7 @@ void dafBase::PropertySet::_add(
   * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
   */
 void dafBase::PropertySet::_findOrInsert(
-    std::string const& name, boost::shared_ptr< std::vector<boost::any> > vp) {
+    std::string const& name, std::shared_ptr< std::vector<boost::any> > vp) {
     if (vp->back().type() == typeid(Ptr)) {
         if (_flat) {
             Ptr source = boost::any_cast<Ptr>(vp->back());
@@ -900,7 +900,7 @@ void dafBase::PropertySet::_findOrInsert(
     if (j == _map.end()) {
         PropertySet::Ptr pp(new PropertySet);
         pp->_findOrInsert(suffix, vp);
-        boost::shared_ptr< vector<boost::any> > temp(new vector<boost::any>);
+        std::shared_ptr< vector<boost::any> > temp(new vector<boost::any>);
         temp->push_back(pp);
         _map[prefix] = temp;
         return;

--- a/tests/PropertyList.cc
+++ b/tests/PropertyList.cc
@@ -53,9 +53,9 @@ BOOST_AUTO_TEST_CASE(bases) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm
     dafBase::PropertyList::Ptr plp(new dafBase::PropertyList);
     dafBase::PropertySet::Ptr psp = plp;
     BOOST_CHECK_EQUAL(!plp, false);
-    boost::shared_ptr<dafBase::Persistable> pp = plp;
+    std::shared_ptr<dafBase::Persistable> pp = plp;
     BOOST_CHECK_EQUAL(!pp, false);
-    boost::shared_ptr<dafBase::Citizen> cp = plp;
+    std::shared_ptr<dafBase::Citizen> cp = plp;
     BOOST_CHECK_EQUAL(!cp, false);
 }
 
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(deepCopy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Lss
     dafBase::PropertySet::Ptr psp2 = psp->deepCopy();
     BOOST_CHECK_EQUAL(psp2->get<int>("int"), 31);
     dafBase::PropertyList::Ptr plp2 =
-        boost::dynamic_pointer_cast<dafBase::PropertyList,
+        std::dynamic_pointer_cast<dafBase::PropertyList,
         dafBase::PropertySet>(psp2);
     BOOST_CHECK_EQUAL(!plp2, false);
     BOOST_CHECK_EQUAL(plp2->get<int>("int"), 31);
@@ -427,12 +427,12 @@ BOOST_AUTO_TEST_CASE(combineAsPS) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a 
     plp1->set("int", 42, "comment");
     plp2->set("float", 3.14159, "stuff");
     dafBase::PropertySet::Ptr psp =
-        boost::static_pointer_cast<dafBase::PropertySet,
+        std::static_pointer_cast<dafBase::PropertySet,
         dafBase::PropertyList>(plp1);
     psp.get()->set("foo", 36);
     psp.get()->combine(plp2);
     dafBase::PropertyList::Ptr newPlp =
-        boost::dynamic_pointer_cast<dafBase::PropertyList,
+        std::dynamic_pointer_cast<dafBase::PropertyList,
         dafBase::PropertySet>(psp);
     BOOST_CHECK_EQUAL(!newPlp, false);
     BOOST_CHECK_EQUAL(newPlp->get<int>("int"), 42);

--- a/tests/PropertySet_1.cc
+++ b/tests/PropertySet_1.cc
@@ -49,11 +49,11 @@ BOOST_AUTO_TEST_CASE(construct) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Ls
 
 BOOST_AUTO_TEST_CASE(bases) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost test harness macros" */
     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-    boost::shared_ptr<dafBase::Persistable> pp =
-        boost::dynamic_pointer_cast<dafBase::Persistable, dafBase::PropertySet>(psp);
+    std::shared_ptr<dafBase::Persistable> pp =
+        std::dynamic_pointer_cast<dafBase::Persistable, dafBase::PropertySet>(psp);
     BOOST_CHECK_EQUAL(!pp, false);
-    boost::shared_ptr<dafBase::Citizen> cp =
-        boost::dynamic_pointer_cast<dafBase::Citizen, dafBase::PropertySet>(psp);
+    std::shared_ptr<dafBase::Citizen> cp =
+        std::dynamic_pointer_cast<dafBase::Citizen, dafBase::PropertySet>(psp);
     BOOST_CHECK_EQUAL(!cp, false);
 }
 

--- a/tests/citizen.cc
+++ b/tests/citizen.cc
@@ -21,10 +21,11 @@
  */
  
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 #include <boost/format.hpp>
-#include <memory>
+
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 

--- a/tests/citizen.cc
+++ b/tests/citizen.cc
@@ -24,8 +24,7 @@
 #include <stdexcept>
 
 #include <boost/format.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 

--- a/tests/citizen.cc
+++ b/tests/citizen.cc
@@ -46,7 +46,7 @@ class MyClass : public lsst::daf::base::Citizen {
     }
     int add_one() { return ++*ptr; }
 private:
-    boost::scoped_ptr<int> ptr;         // no need to track this alloc
+    std::unique_ptr<int> ptr;         // no need to track this alloc
 };
 
 using namespace lsst::daf::base;
@@ -63,7 +63,7 @@ using namespace lsst::daf::base;
 BOOST_AUTO_TEST_SUITE(CitizenSuite)
 
 MyClass *foo() {
-    boost::scoped_ptr<Shoe> x(new Shoe(1));
+    std::unique_ptr<Shoe> x(new Shoe(1));
     MyClass *my_instance = new MyClass();
 
     BOOST_CHECK_EQUAL(Citizen::census(0), 5);
@@ -78,12 +78,12 @@ BOOST_AUTO_TEST_CASE(all) {
     Shoe x;
     const Citizen::memId firstId = Citizen::getNextMemId(); // after allocating x
     
-    boost::scoped_ptr<Shoe> y(new Shoe);
-    boost::scoped_ptr<Shoe> z(new Shoe(10));
+    std::unique_ptr<Shoe> y(new Shoe);
+    std::unique_ptr<Shoe> z(new Shoe(10));
     
     MyClass *mine = foo();
 
-    boost::scoped_ptr<const std::vector<const Citizen *> > leaks(Citizen::census());
+    std::unique_ptr<const std::vector<const Citizen *> > leaks(Citizen::census());
     BOOST_CHECK_EQUAL(leaks->end() - leaks->begin(), 4);
     BOOST_CHECK_EQUAL(Citizen::census(0), 4);
     BOOST_CHECK_EQUAL(Citizen::census(0, firstId), 3);


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
