### PR TITLE
DM-8461: Wrap pipe_tasks with pybind11

### DIFF
--- a/python/lsst/daf/base/citizen.cc
+++ b/python/lsst/daf/base/citizen.cc
@@ -24,7 +24,6 @@ PYBIND11_PLUGIN(_citizen) {
         py::return_value_policy::reference);
     cls.def("getId", &Citizen::getId);
     cls.def("markPersistent", &Citizen::markPersistent);
-    cls.def("repr", &Citizen::repr);
     cls.def_static("getNextMemId", &Citizen::getNextMemId);
     cls.def_static("setNewCallbackId", &Citizen::setNewCallbackId);
     cls.def_static("setDeleteCallbackId", &Citizen::setDeleteCallbackId);


### PR DESCRIPTION
After merging Pim's and my changes, there were two wrappers for `Citizen::repr` in the file. I've removed my copy of the wrapper.