### PR TITLE
DM-13655: Phase out MemoryError and TimeoutError from pex::exceptions

### DIFF
--- a/examples/citizen.cc
+++ b/examples/citizen.cc
@@ -26,7 +26,6 @@
 
 #include <boost/format.hpp>
 
-#include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 
 //
@@ -122,8 +121,8 @@ int main() {
     try {
         std::cerr << "Checking corruption\n";
         (void)Citizen::hasBeenCorrupted();
-    } catch(lsst::pex::exceptions::MemoryError& e) {
-        std::cerr << "Memory check: " << e <<
+    } catch(std::bad_alloc& e) {
+        std::cerr << "Memory check: " << e.what() <<
             "Proceeding with trepidation\n";
         ((int *)y.get())[0] = 0xdeadbeef; // uncorrupt the block
     }

--- a/src/Citizen.cc
+++ b/src/Citizen.cc
@@ -34,7 +34,6 @@
 #include <boost/format.hpp>
 
 #include "lsst/daf/base/Citizen.h"
-#include "lsst/pex/exceptions.h"
 #include "lsst/utils/Demangle.h"
 
 namespace dafBase = lsst::daf::base;
@@ -47,8 +46,7 @@ public:
     ThreadPrivate(T const& t) : _init(t) {
         int ret = pthread_key_create(&_key, del);
         if (ret != 0) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                              "Could not create key");
+            throw std::bad_alloc();
         }
     };
     T& getRef(void) {
@@ -78,29 +76,25 @@ public:
     RwLock(void) {
         int ret = pthread_rwlock_init(&_lock, 0);
         if (ret != 0) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                              "Could not create Citizen lock");
+            throw std::bad_alloc();
         }
     };
     void lock(void) {
         int ret = pthread_rwlock_wrlock(&_lock);
         if (ret != 0) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                              "Could not acquire Citizen write lock");
+            throw std::bad_alloc();
         }
     };
     bool rdlock(void) {
         int ret = pthread_rwlock_rdlock(&_lock);
         if (ret == 0) return true;
         if (ret == EDEADLK) return false;
-        throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                          "Could not acquire Citizen read lock");
+        throw std::bad_alloc();
     };
     void unlock(void) {
         int ret = pthread_rwlock_unlock(&_lock);
         if (ret != 0) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                              "Could not release Citizen lock");
+            throw std::bad_alloc();
         }
     };
 
@@ -465,8 +459,7 @@ dafBase::Citizen::memId defaultDeleteCallback(dafBase::Citizen const* ptr //!< A
 //! Default CorruptionCallback
 dafBase::Citizen::memId defaultCorruptionCallback(dafBase::Citizen const* ptr //!< About-to-be deleted Citizen
                               ) {
-    throw LSST_EXCEPT(lsst::pex::exceptions::MemoryError,
-                      str(boost::format("Citizen \"%s\" is corrupted") % ptr->repr()));
+    throw std::bad_alloc();
 
     return ptr->getId();                // NOTREACHED
 }

--- a/tests/test_citizen.cc
+++ b/tests/test_citizen.cc
@@ -26,7 +26,6 @@
 
 #include <boost/format.hpp>
 
-#include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/Citizen.h"
 
 class Shoe : public lsst::daf::base::Citizen {
@@ -96,7 +95,7 @@ BOOST_AUTO_TEST_CASE(all) {
 
 #if 0                                   // can crash the program.  Drat.
     ((int *)y.get())[0] = 0;            // deliberately corrupt the block
-    BOOST_CHECK_THROW((void)Citizen::checkCorruption(), lsst::pex::exceptions::MemoryError);
+    BOOST_CHECK_THROW((void)Citizen::checkCorruption(), std::bad_alloc);
     ((int *)y.get())[0] = 0xdeadbeef;   // uncorrupt the block
 #endif
 


### PR DESCRIPTION
This PR removes all mention of `pex::exceptions::MemoryError` from `daf_base`, modifying code to throw `std::bad_alloc` instead.

This change removes error messages from the emitted exception, but there's a good chance that trying to allocate the strings for those would have triggered `bad_alloc` anyway.