### PR TITLE
DM-15676: Add dict-like functionality to PropertySet and PropertyList

### DIFF
--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -112,7 +112,7 @@ def setPropertySetState(container, state):
         The property container whose state is to be restored.
         It should be empty to start with and is updated in place.
     state : `list`
-        The state, as returned by ``getPropertySetState``
+        The state, as returned by `getPropertySetState`
     """
     for name, elemType, value in state:
         if elemType is not None:
@@ -364,7 +364,7 @@ class PropertySet:
         """Return an item as an array if the item is numeric or string
 
         If the item is a `PropertySet`, `PropertyList` or
-        ``lsst.daf.base.PersistablePtr`` then return the item as a scalar.
+        `lsst.daf.base.PersistablePtr` then return the item as a scalar.
 
         Parameters
         ----------

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -27,6 +27,7 @@ __all__ = ["getPropertySetState", "getPropertyListState", "setPropertySetState",
 import enum
 import numbers
 import warnings
+from collections.abc import Mapping
 
 from lsst.utils import continueClass
 
@@ -494,6 +495,12 @@ class PropertySet:
         return name in self.names(topLevelOnly=True)
 
     def __setitem__(self, name, value):
+        if isinstance(value, Mapping):
+            # Create a property set instead
+            ps = PropertySet()
+            for k, v in value.items():
+                ps[k] = v
+            value = ps
         self.set(name, value)
 
     def __getitem__(self, name):

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -329,13 +329,6 @@ class PropertySet:
                  PropertyList: "PropertySet",
                  }
 
-    # Map unicode to String, but this only works on Python 2
-    # so catch the error and do nothing on Python 3.
-    try:
-        _typeMenu[unicode] = "String"  # noqa F821
-    except Exception:
-        pass
-
     def get(self, name):
         """Return an item as a scalar or array
 
@@ -509,13 +502,6 @@ class PropertyList:
                  PropertySet: "PropertySet",
                  PropertyList: "PropertySet",
                  }
-
-    # Map unicode to String, but this only works on Python 2
-    # so catch the error and do nothing on Python 3.
-    try:
-        _typeMenu[unicode] = "String"  # noqa F821
-    except Exception:
-        pass
 
     def get(self, name):
         """Return an item as a scalar or array

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -462,14 +462,6 @@ class PropertySet:
                 d[name] = v
         return d
 
-    def items(self):
-        for name in self:
-            yield name, _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
-
-    def values(self):
-        for name in self:
-            yield _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
-
     def __eq__(self, other):
         if type(self) != type(other):
             return False
@@ -505,9 +497,6 @@ class PropertySet:
                 ps[k] = v
             value = ps
         self.set(name, value)
-
-    def __getitem__(self, name):
-        return _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
 
     def __delitem__(self, name):
         if name in self:
@@ -737,7 +726,6 @@ class PropertyList:
     keys = __iter__
 
     def __setitem__(self, name, value):
-        print(f"Processing setitem: {name}: {value}")
         if name.endswith(self.COMMENTSUFFIX):
             name = name[:-len(self.COMMENTSUFFIX)]
             self.setComment(name, value)
@@ -749,14 +737,6 @@ class PropertyList:
                 ps[k] = v
             value = ps
         self.set(name, value)
-
-    def __getitem__(self, name):
-        if name.endswith(self.COMMENTSUFFIX):
-            name = name[:-len(self.COMMENTSUFFIX)]
-            return self.getComment(name)
-
-        # Always return SCALAR? (ie disallow retrieval of COMMENT/HISTORY)
-        return _propertyContainerGet(self, name, returnStyle=ReturnStyle.SCALAR)
 
     def __reduce__(self):
         # It would be a bit simpler to use __setstate__ and __getstate__.

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -27,7 +27,7 @@ __all__ = ["getPropertySetState", "getPropertyListState", "setPropertySetState",
 import enum
 import numbers
 import warnings
-from collections.abc import Mapping
+from collections.abc import Mapping, KeysView
 
 from lsst.utils import continueClass
 
@@ -514,7 +514,8 @@ class PropertySet:
         for n in self.names(topLevelOnly=True):
             yield n
 
-    keys = __iter__
+    def keys(self):
+        return KeysView(self)
 
     def __reduce__(self):
         # It would be a bit simpler to use __setstate__ and __getstate__.
@@ -722,8 +723,6 @@ class PropertyList:
     def __iter__(self):
         for n in self.getOrderedNames():
             yield n
-
-    keys = __iter__
 
     def __setitem__(self, name, value):
         if name.endswith(self.COMMENTSUFFIX):

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -63,8 +63,11 @@ def getPropertySetState(container, asLists=False, names=None):
             with the set method named by ``elementTypeName``
     """
     if names is None:
-        # All names, including dot-delimiter subproperties
-        names = container.paramNames(False)
+        # All top level names: this allows hierarchical PropertySet and
+        # PropertyList to be represented as their own entities. Without
+        # this a PropertyList inside a PropertySet loses all comments
+        # and becomes a PropertySet.
+        names = container.names(topLevelOnly=True)
     sequence = list if asLists else tuple
     return [sequence((name, _propertyContainerElementTypeName(container, name),
             _propertyContainerGet(container, name, returnStyle=ReturnStyle.AUTO)))

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -443,6 +443,39 @@ class PropertySet:
                 d[name] = v
         return d
 
+    def items(self):
+        for name in self:
+            yield name, _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+
+        if len(self) != len(other):
+            return False
+
+        for name in self:
+            if _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO) != \
+                    _propertyContainerGet(other, name, returnStyle=ReturnStyle.AUTO):
+                return False
+            if self.typeOf(name) != other.typeOf(name):
+                return False
+
+        return True
+
+    def __getitem__(self, name):
+        return _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
+
+    def __str__(self):
+        return self.toString()
+
+    def __len__(self):
+        return len(self.names())
+
+    def __iter__(self):
+        for n in self.names():
+            yield n
+
     def __reduce__(self):
         # It would be a bit simpler to use __setstate__ and __getstate__.
         # However, implementing __setstate__ in Python causes segfaults
@@ -614,6 +647,20 @@ class PropertyList:
         for name in self.getOrderedNames():
             d[name] = _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
         return d
+
+    def __eq__(self, other):
+        if not super(PropertySet, self).__eq__(other):
+            return False
+
+        for name in self:
+            if self.getComment(name) != other.getComment(name):
+                return False
+
+        return True
+
+    def __iter__(self):
+        for n in self.getOrderedNames():
+            yield n
 
     def __reduce__(self):
         # It would be a bit simpler to use __setstate__ and __getstate__.

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -43,6 +43,7 @@ class PropertyListTestCase(unittest.TestCase):
     def checkPickle(self, original):
         new = pickle.loads(pickle.dumps(original, 2))
         self.assertEqual(new, original)
+        return new
 
     def testScalar(self):
         apl = dafBase.PropertyList()
@@ -336,6 +337,16 @@ class PropertyListTestCase(unittest.TestCase):
                          'top.sibling = 42\ntop.bottom = "x"\n')
 
         self.checkPickle(apl)
+
+        # Check that a PropertyList (with comment) can go in a PropertySet
+        apl.set("INT", 45, "an integer")
+        aps = dafBase.PropertySet()
+        aps.set("bottom", "x")
+        aps.set("apl", apl)
+        new = self.checkPickle(aps)
+        self.assertIsInstance(new, dafBase.PropertySet)
+        self.assertIsInstance(new.getScalar("apl"), dafBase.PropertyList)
+        self.assertEqual(new.getScalar("apl").getComment("INT"), "an integer")
 
     def testCombineHierarchical(self):
         # Test that we can perform a deep copy of a PropertyList containing a

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -26,7 +26,6 @@ import unittest
 
 import lsst.utils.tests
 import lsst.daf.base as dafBase
-import lsst.pex.exceptions as pexExcept
 
 
 class FloatSubClass(float):
@@ -184,23 +183,23 @@ class PropertyListTestCase(unittest.TestCase):
         apl.setDouble("double", 2.718281828459045)
         apl.setString("string", "bar")
         with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(pexExcept.NotFoundError):
+            with self.assertRaises(KeyError):
                 apl.get("foo")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getBool("short")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getBool("int")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getShort("int")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getInt("short")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getInt("bool")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getDouble("float")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getFloat("double")
-        with self.assertRaises(pexExcept.TypeError):
+        with self.assertRaises(TypeError):
             apl.getString("int")
 
     def testAddVector(self):
@@ -337,7 +336,7 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(apl.getArray("top.sibling"), [42])
         self.assertEqual(apl.getScalar("top.sibling"), 42)
         with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(pexExcept.NotFoundError):
+            with self.assertRaises(KeyError):
                 apl.get("top")
         self.assertEqual(apl.toString(),
                          'CURRENT = 49.500000000000\nCURRENT.foo = -32\nCURRENT.bar = 2\n'

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -359,6 +359,7 @@ class PropertyListTestCase(unittest.TestCase):
             self.assertEqual(pl1.get("a.b"), pl2.get("a.b"))
         self.assertEqual(pl1.getArray("a.b"), pl2.getArray("a.b"))
         self.assertEqual(pl1.getScalar("a.b"), pl2.getScalar("a.b"))
+        self.checkPickle(pl1)
 
     def testCopy(self):
         dest = dafBase.PropertyList()
@@ -388,6 +389,365 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(dest.getArray("destItem2Scalar"), [value2[-1]])
         self.assertEqual(dest.getScalar("destItem2Scalar"), value2[-1])
 
+    def testArrayProperties(self):
+        apl = dafBase.PropertyList()
+        v = [42, 2008, 1]
+        apl.set("ints", v)
+        apl.set("int", 365)
+        apl.set("ints2", -42)
+        apl.add("ints2", -2008)
+
+        self.assertTrue(apl.isArray("ints"))
+        self.assertFalse(apl.isArray("int"))
+        self.assertTrue(apl.isArray("ints2"))
+        self.assertEqual(apl.valueCount("ints"), 3)
+        self.assertEqual(apl.valueCount("int"), 1)
+        self.assertEqual(apl.valueCount("ints2"), 2)
+        self.assertEqual(apl.typeOf("ints"), dafBase.PropertyList.TYPE_Int)
+        self.assertEqual(apl.typeOf("int"), dafBase.PropertyList.TYPE_Int)
+        self.assertEqual(apl.typeOf("ints2"), dafBase.PropertyList.TYPE_Int)
+
+    def testHierarchy2(self):
+        apl = dafBase.PropertyList()
+        aplp = dafBase.PropertyList()
+
+        aplp.set("pre", 1)
+        apl.set("apl1", aplp)
+
+        # Python will not see this, aplp is disconnected
+        aplp.set("post", 2)
+        self.assertFalse(apl.exists("apl1.post"))
+
+        apl.set("int", 42)
+
+        # Setting an empty PropertyList has no effect
+        apl.set("apl2", dafBase.PropertyList())
+        self.assertFalse(apl.exists("apl2"))
+
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+        apl.set("apl3.sub1", "foo")
+        apl.set("apl3.sub2", "bar")
+
+        self.assertTrue(apl.exists("apl1.pre"))
+        self.assertTrue(apl.exists("apl2.plus"))
+        self.assertTrue(apl.exists("apl2.minus"))
+        self.assertTrue(apl.exists("apl3.sub1"))
+        self.assertTrue(apl.exists("apl3.sub2"))
+
+        # Make sure checking a subproperty doesn't create it.
+        self.assertFalse(apl.exists("apl2.pre"))
+        self.assertFalse(apl.exists("apl2.pre"))
+        # Make sure checking an element doesn't create it.
+        self.assertFalse(apl.exists("apl4"))
+        self.assertFalse(apl.exists("apl4"))
+        # Make sure checking a subproperty with a nonexistent parent doesn't
+        # create it.
+        self.assertFalse(apl.exists("apl4.sub"))
+        self.assertFalse(apl.exists("apl4.sub"))
+        # Make sure checking a subproperty doesn't create its parent.
+        self.assertFalse(apl.exists("apl4"))
+
+    def testvariousThrows(self):
+        apl = dafBase.PropertyList()
+        apl.set("int", 42)
+
+        # This raises an exception in C++ test but works in Python
+        apl.set("int.sub", "foo")
+
+        with self.assertRaises(TypeError):
+            apl.getDouble("int")
+        with self.assertRaises(LookupError):
+            apl.getDouble("double"),
+        with self.assertRaises(LookupError):
+            apl.getArrayDouble("double")
+        with self.assertRaises(LookupError):
+            apl.typeOf("double")
+        with self.assertRaises(TypeError):
+            apl.add("int", 4.2),
+
+        v = [3.14159, 2.71828]
+        with self.assertRaises(TypeError):
+            apl.add("int", v)
+        apl.remove("foo.bar")
+        apl.remove("int.sub")
+
+    def testNames(self):
+        apl = dafBase.PropertyList()
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("int", 42)
+        apl.set("double", 3.14)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+
+        # Hierarchy is always flat
+        self.assertEqual(apl.nameCount(), 6)
+        self.assertEqual(apl.nameCount(False), 6)
+
+        v = set(apl.names())
+        self.assertEqual(len(v), 6)
+        self.assertEqual(v, {"double", "int", "apl1.post",
+                             "apl1.pre", "apl2.minus", "apl2.plus"})
+
+    def testParamNames(self):
+        apl = dafBase.PropertyList()
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("int", 42)
+        apl.set("double", 3.14)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+
+        v = set(apl.paramNames())
+        self.assertEqual(len(v), 6)
+        self.assertEqual(v, {"double", "int", "apl1.post", "apl1.pre",
+                             "apl2.minus", "apl2.plus"})
+
+    def testPropertySetNames(self):
+        apl = dafBase.PropertyList()
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("int", 42)
+        apl.set("double", 3.14)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+        apl.set("apl3.sub.subsub", "foo")
+
+        # There are no PropertySets inside flattened PropertyList
+        v = set(apl.propertySetNames())
+        print(v)
+        self.assertEqual(len(v), 0)
+
+    def testGetAs(self):
+        apl = dafBase.PropertyList()
+        apl.set("bool", True)
+        s = 42
+        apl.setShort("short", s)
+        apl.set("int", 2008)
+        apl.set("int64_t", 0xfeeddeadbeef)
+        f = 3.14159
+        apl.setFloat("float", f)
+        d = 2.718281828459045
+        apl.setDouble("double", d)
+        apl.setString("char*", "foo")
+        apl.set("char*2", "foo2")
+        apl.set("string", "bar")
+        aplp = dafBase.PropertyList()
+        aplp.set("bottom", "x")
+        apl.set("top", aplp)
+
+        self.assertEqual(apl.getAsBool("bool"), True)
+        self.assertEqual(apl.getAsInt("bool"), 1)
+        self.assertEqual(apl.getAsInt("short"), 42)
+        self.assertEqual(apl.getAsInt("int"), 2008)
+        with self.assertRaises(TypeError):
+            apl.getAsInt("int64_t")
+        self.assertEqual(apl.getAsInt64("bool"), 1)
+        self.assertEqual(apl.getAsInt64("short"), 42)
+        self.assertEqual(apl.getAsInt64("int"), 2008)
+        self.assertEqual(apl.getAsInt64("int64_t"), 0xfeeddeadbeef)
+        with self.assertRaises(TypeError):
+            apl.getAsInt64("float")
+        self.assertEqual(apl.getAsDouble("bool"), 1.0)
+        self.assertEqual(apl.getAsDouble("short"), 42.0)
+        self.assertEqual(apl.getAsDouble("int"), 2008.0)
+        self.assertEqual(apl.getAsDouble("int64_t"), float(0xfeeddeadbeef))
+        self.assertAlmostEqual(apl.getAsDouble("float"), 3.14159, places=5)
+        self.assertEqual(apl.getAsDouble("double"), 2.718281828459045)
+        with self.assertRaises(TypeError):
+            apl.getAsDouble("char*")
+        self.assertEqual(apl.getAsString("char*"), "foo")
+        self.assertEqual(apl.getAsString("char*2"), "foo2")
+        self.assertEqual(apl.getAsString("string"), "bar")
+        with self.assertRaises(TypeError):
+            apl.getAsString("int")
+        self.assertEqual(apl.getAsString("top.bottom"), "x")
+
+    def testCombine(self):
+        apl = dafBase.PropertyList()
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("int", 42)
+        apl.set("double", 3.14)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+        apl.set("apl3.sub.subsub", "foo")
+
+        aplp = dafBase.PropertyList()
+        aplp.set("apl1.pre", 3)
+        aplp.add("apl1.pre", 4)
+        aplp.set("int", 2008)
+        aplp.set("apl2.foo", "bar")
+        aplp.set("apl4.top", "bottom")
+
+        apl.combine(aplp)
+
+        self.assertFalse(apl.isArray("apl1"))
+        self.assertTrue(apl.isArray("apl1.pre"))
+        self.assertFalse(apl.isArray("apl1.post"))
+        self.assertFalse(apl.isArray("apl2"))
+        self.assertFalse(apl.isArray("apl2.plus"))
+        self.assertFalse(apl.isArray("apl2.minus"))
+        self.assertFalse(apl.isArray("apl2.foo"))
+        self.assertFalse(apl.isArray("apl3"))
+        self.assertFalse(apl.isArray("apl3.sub"))
+        self.assertFalse(apl.isArray("apl3.subsub"))
+        self.assertFalse(apl.isArray("apl4"))
+        self.assertFalse(apl.isArray("apl4.top"))
+        self.assertTrue(apl.isArray("int"))
+        self.assertFalse(apl.isArray("double"))
+        self.assertEqual(apl.valueCount("apl1.pre"), 3)
+        self.assertEqual(apl.valueCount("int"), 2)
+        v = apl.getArray("apl1.pre")
+        self.assertEqual(v, [1, 3, 4])
+        v = apl.getArray("int")
+        self.assertEqual(v, [42, 2008])
+
+    def testCombineThrow(self):
+        apl = dafBase.PropertyList()
+        apl.set("int", 42)
+
+        aplp = dafBase.PropertyList()
+        aplp.set("int", 3.14159)
+
+        with self.assertRaises(TypeError):
+            apl.combine(aplp)
+
+    def testremove(self):
+        apl = dafBase.PropertyList()
+        apl.set("int", 42)
+        apl.set("double", 3.14159)
+        apl.set("apl1.plus", 1)
+        apl.set("apl1.minus", -1)
+        apl.set("apl1.zero", 0)
+        self.assertEqual(apl.nameCount(False), 5)
+
+        apl.remove("int")
+        self.assertFalse(apl.exists("int"))
+        self.assertEqual(apl.getAsDouble("double"), 3.14159)
+        self.assertEqual(apl.getAsInt("apl1.plus"), 1)
+        self.assertEqual(apl.getAsInt("apl1.minus"), -1)
+        self.assertEqual(apl.getAsInt("apl1.zero"), 0)
+        self.assertEqual(apl.nameCount(False), 4)
+
+        apl.remove("apl1.zero")
+        self.assertFalse(apl.exists("int"))
+        self.assertEqual(apl.getAsDouble("double"), 3.14159)
+        self.assertFalse(apl.exists("apl1.zero"))
+        self.assertEqual(apl.getAsInt("apl1.plus"), 1)
+        self.assertEqual(apl.getAsInt("apl1.minus"), -1)
+        self.assertEqual(apl.nameCount(False), 3)
+
+        # Removing a non-existent key (flattened) has no effect
+        self.assertFalse(apl.exists("apl1"))
+        apl.remove("apl1")
+        self.assertFalse(apl.exists("int"))
+        self.assertEqual(apl.getAsDouble("double"), 3.14159)
+        self.assertFalse(apl.exists("apl1"))
+        self.assertTrue(apl.exists("apl1.plus"))
+        self.assertTrue(apl.exists("apl1.minus"))
+        self.assertFalse(apl.exists("apl1.zero"))
+        self.assertEqual(apl.nameCount(False), 3)
+
+        apl.remove("double")
+        self.assertFalse(apl.exists("int"))
+        self.assertFalse(apl.exists("double"))
+        self.assertFalse(apl.exists("apl1"))
+        self.assertTrue(apl.exists("apl1.plus"))
+        self.assertTrue(apl.exists("apl1.minus"))
+        self.assertFalse(apl.exists("apl1.zero"))
+        self.assertEqual(apl.nameCount(False), 2)
+
+        apl.remove("apl1.plus")
+        apl.remove("apl1.minus")
+        self.assertEqual(apl.nameCount(False), 0)
+
+    def testdeepCopy(self):
+        apl = dafBase.PropertyList()
+        apl.set("int", 42)
+        aplp = dafBase.PropertyList()
+        aplp.set("bottom", "x")
+        apl.set("top", aplp)
+
+        aplp2 = apl.deepCopy()
+        self.assertTrue(aplp2.exists("int"))
+        self.assertTrue(aplp2.exists("top.bottom"))
+        self.assertEqual(aplp2.getAsInt("int"), 42)
+        self.assertEqual(aplp2.getAsString("top.bottom"), "x")
+        # Make sure it was indeed a deep copy.
+        apl.set("int", 2008)
+        apl.set("top.bottom", "z")
+        self.assertEqual(apl.getAsInt("int"), 2008)
+        self.assertEqual(apl.getAsString("top.bottom"), "z")
+        self.assertEqual(aplp2.getAsInt("int"), 42)
+        self.assertEqual(aplp2.getAsString("top.bottom"), "x")
+
+    def testToString(self):
+        apl = dafBase.PropertyList()
+        apl.set("bool", True)
+        s = 42
+        apl.setShort("short", s)
+        apl.set("int", 2008)
+        apl.set("int64_t", 0xfeeddeadbeef)
+        f = 3.14159
+        apl.setFloat("float", f)
+        d = 2.718281828459045
+        apl.setDouble("double", d)
+        apl.setString("char*", "foo")
+        apl.set("char*2", "foo2")
+        apl.set("string", "bar")
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+        apl.set("apl3.sub.subsub", "foo")
+        apl.add("v", 10)
+        apl.add("v", 9)
+        apl.add("v", 8)
+
+        # Check that the keys returned for this PropertyList match
+        # the order they were set
+        order = ['bool', 'short', 'int', 'int64_t', 'float', 'double', 'char*', 'char*2',
+                 'string', 'apl1.pre', 'apl1.post', 'apl2.plus', 'apl2.minus', 'apl3.sub.subsub', 'v']
+        self.assertEqual(apl.getOrderedNames(), order)
+
+        # Argument to toString has no effect for flattened hierarchy
+        self.assertEqual(apl.toString(),
+                         "bool = 1\n"
+                         "short = 42\n"
+                         "int = 2008\n"
+                         "int64_t = 280297596632815\n"
+                         "float = 3.141590\n"
+                         "double = 2.7182818284590\n"
+                         "char* = \"foo\"\n"
+                         "char*2 = \"foo2\"\n"
+                         "string = \"bar\"\n"
+                         "apl1.pre = 1\n"
+                         "apl1.post = 2\n"
+                         "apl2.plus = 10.240000000000\n"
+                         "apl2.minus = -10.240000000000\n"
+                         "apl3.sub.subsub = \"foo\"\n"
+                         "v = [ 10, 9, 8 ]\n"
+                         )
+        self.assertEqual(apl.toString(True),
+                         "bool = 1\n"
+                         "short = 42\n"
+                         "int = 2008\n"
+                         "int64_t = 280297596632815\n"
+                         "float = 3.141590\n"
+                         "double = 2.7182818284590\n"
+                         "char* = \"foo\"\n"
+                         "char*2 = \"foo2\"\n"
+                         "string = \"bar\"\n"
+                         "apl1.pre = 1\n"
+                         "apl1.post = 2\n"
+                         "apl2.plus = 10.240000000000\n"
+                         "apl2.minus = -10.240000000000\n"
+                         "apl3.sub.subsub = \"foo\"\n"
+                         "v = [ 10, 9, 8 ]\n"
+                         )
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
@@ -400,455 +760,3 @@ def setup_module(module):
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()
-
-# BOOST_AUTO_TEST_CASE(arrayProperties) {
-#     dafBase::PropertyList apl;
-#     std::vector<int> v;
-#     v.push_back(42);
-#     v.push_back(2008);
-#     v.push_back(1);
-#     apl.set("ints", v);
-#     apl.set("int", 365);
-#     apl.set("ints2", -42);
-#     apl.add("ints2", -2008);
-#
-#     BOOST_CHECK_EQUAL(apl.isArray("ints"), true);
-#     BOOST_CHECK_EQUAL(apl.isArray("int"), false);
-#     BOOST_CHECK_EQUAL(apl.isArray("ints2"), true);
-#     BOOST_CHECK_EQUAL(apl.valueCount("ints"), 3U);
-#     BOOST_CHECK_EQUAL(apl.valueCount("int"), 1U);
-#     BOOST_CHECK_EQUAL(apl.valueCount("ints2"), 2U);
-#     BOOST_CHECK(apl.typeOf("ints") == typeid(int));
-#     BOOST_CHECK(apl.typeOf("int") == typeid(int));
-#     BOOST_CHECK(apl.typeOf("ints2") == typeid(int));
-# }
-#
-# BOOST_AUTO_TEST_CASE(hierarchy) {
-#     dafBase::PropertyList apl;
-#     dafBase::PropertyList::Ptr aplp(new
-#     dafBase::PropertyList);
-#
-#     aplp->set("pre", 1);
-#     apl.set("apl1", aplp);
-#     aplp->set("post", 2);
-#     apl.set("int", 42);
-#     apl.set("apl2", dafBase::PropertyList::Ptr(new
-#     dafBase::PropertyList));
-#     apl.get<dafBase::PropertyList::Ptr>("apl2")->set("plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#     apl.set("apl3.sub1", "foo");
-#     apl.set("apl3.sub2", "bar");
-#
-#     BOOST_CHECK(apl.exists("apl1"));
-#     BOOST_CHECK(apl.exists("apl2"));
-#     BOOST_CHECK(apl.exists("apl3"));
-#     BOOST_CHECK(apl.exists("apl1.pre"));
-#     BOOST_CHECK(apl.exists("apl1.post"));
-#     BOOST_CHECK(apl.exists("apl2.plus"));
-#     BOOST_CHECK(apl.exists("apl2.minus"));
-#     BOOST_CHECK(apl.exists("apl3.sub1"));
-#     BOOST_CHECK(apl.exists("apl3.sub2"));
-#
-#     BOOST_CHECK(apl.isPropertyListPtr("apl1"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl2"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl3"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("int"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl1.pre"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl1.post"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl2.plus"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl2.minus"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl3.sub1"));
-#     BOOST_CHECK(!apl.isPropertyListPtr("apl3.sub2"));
-#
-#     dafBase::PropertyList::Ptr aplp1 =
-#     apl.get<dafBase::PropertyList::Ptr>("apl1");
-#     dafBase::PropertyList::Ptr aplp2 =
-#     apl.get<dafBase::PropertyList::Ptr>("apl2");
-#     dafBase::PropertyList::Ptr aplp3 =
-#     apl.get<dafBase::PropertyList::Ptr>("apl3");
-#     BOOST_CHECK(aplp1);
-#     BOOST_CHECK(aplp2);
-#     BOOST_CHECK(aplp3);
-#     BOOST_CHECK(aplp1 == aplp);
-#     BOOST_CHECK(aplp1->exists("pre"));
-#     BOOST_CHECK(aplp1->exists("post"));
-#     BOOST_CHECK(aplp2->exists("plus"));
-#     BOOST_CHECK(aplp2->exists("minus"));
-#     BOOST_CHECK(aplp3->exists("sub1"));
-#     BOOST_CHECK(aplp3->exists("sub2"));
-#     BOOST_CHECK_EQUAL(aplp1->get<int>("pre"), 1);
-#     BOOST_CHECK_EQUAL(aplp1->get<int>("post"), 2);
-#     BOOST_CHECK_EQUAL(aplp2->get<double>("plus"), 10.24);
-#     BOOST_CHECK_EQUAL(aplp2->get<double>("minus"), -10.24);
-#     BOOST_CHECK_EQUAL(aplp3->get<std::string>("sub1"), "foo");
-#     BOOST_CHECK_EQUAL(aplp3->get<std::string>("sub2"), "bar");
-#
-#     // Make sure checking a subproperty doesn't create it.
-#     BOOST_CHECK(!apl.exists("apl2.pre"));
-#     BOOST_CHECK(!apl.exists("apl2.pre"));
-#     // Make sure checking an element doesn't create it.
-#     BOOST_CHECK(!apl.exists("apl4"));
-#     BOOST_CHECK(!apl.exists("apl4"));
-#     // Make sure checking a subproperty with a nonexistent parent doesn't
-#     // create it.
-#     BOOST_CHECK(!apl.exists("apl4.sub"));
-#     BOOST_CHECK(!apl.exists("apl4.sub"));
-#     // Make sure checking a subproperty doesn't create its parent.
-#     BOOST_CHECK(!apl.exists("apl4"));
-# }
-#
-# BOOST_AUTO_TEST_CASE(variousThrows) {
-#     dafBase::PropertyList apl;
-#     apl.set("int", 42);
-#     BOOST_CHECK_THROW(apl.set("int.sub", "foo"),
-#                       lsst::pex::exceptions::InvalidParameterError);
-#     BOOST_CHECK_THROW(apl.get<double>("int"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(apl.get<double>("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(apl.getArray<double>("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(apl.typeOf("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(apl.add("int", 4.2),
-#                       lsst::pex::exceptions::DomainError);
-#     std::vector<double> v;
-#     v.push_back(3.14159);
-#     v.push_back(2.71828);
-#     BOOST_CHECK_THROW(apl.add("int", v),
-#                       lsst::pex::exceptions::DomainError);
-#     BOOST_CHECK_NO_THROW(apl.remove("foo.bar"));
-#     BOOST_CHECK_NO_THROW(apl.remove("int.sub"));
-# }
-#
-# BOOST_AUTO_TEST_CASE(names) {
-#     dafBase::PropertyList apl;
-#     apl.set("apl1.pre", 1);
-#     apl.set("apl1.post", 2);
-#     apl.set("int", 42);
-#     apl.set("double", 3.14);
-#     apl.set("apl2.plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#
-#     BOOST_CHECK_EQUAL(apl.nameCount(), 4U);
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 8U);
-#
-#     std::vector<std::string> v = apl.names();
-#     BOOST_CHECK_EQUAL(v.size(), 4U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "apl1");
-#     BOOST_CHECK_EQUAL(v[3], "apl2");
-#     v = apl.names(false);
-#     BOOST_CHECK_EQUAL(v.size(), 8U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "apl1");
-#     BOOST_CHECK_EQUAL(v[3], "apl1.post");
-#     BOOST_CHECK_EQUAL(v[4], "apl1.pre");
-#     BOOST_CHECK_EQUAL(v[5], "apl2");
-#     BOOST_CHECK_EQUAL(v[6], "apl2.minus");
-#     BOOST_CHECK_EQUAL(v[7], "apl2.plus");
-# }
-#
-# BOOST_AUTO_TEST_CASE(paramNames) {
-#     dafBase::PropertyList apl;
-#     apl.set("apl1.pre", 1);
-#     apl.set("apl1.post", 2);
-#     apl.set("int", 42);
-#     apl.set("double", 3.14);
-#     apl.set("apl2.plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#
-#     std::vector<std::string> v = apl.paramNames();
-#     BOOST_CHECK_EQUAL(v.size(), 2U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     v = apl.paramNames(false);
-#     BOOST_CHECK_EQUAL(v.size(), 6U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "apl1.post");
-#     BOOST_CHECK_EQUAL(v[3], "apl1.pre");
-#     BOOST_CHECK_EQUAL(v[4], "apl2.minus");
-#     BOOST_CHECK_EQUAL(v[5], "apl2.plus");
-# }
-#
-# BOOST_AUTO_TEST_CASE(propertySetNames) {
-#     dafBase::PropertyList apl;
-#     apl.set("apl1.pre", 1);
-#     apl.set("apl1.post", 2);
-#     apl.set("int", 42);
-#     apl.set("double", 3.14);
-#     apl.set("apl2.plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#     apl.set("apl3.sub.subsub", "foo");
-#
-#     std::vector<std::string> v = apl.propertySetNames();
-#     BOOST_CHECK_EQUAL(v.size(), 3U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "apl1");
-#     BOOST_CHECK_EQUAL(v[1], "apl2");
-#     BOOST_CHECK_EQUAL(v[2], "apl3");
-#     v = apl.propertySetNames(false);
-#     BOOST_CHECK_EQUAL(v.size(), 4U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "apl1");
-#     BOOST_CHECK_EQUAL(v[1], "apl2");
-#     BOOST_CHECK_EQUAL(v[2], "apl3");
-#     BOOST_CHECK_EQUAL(v[3], "apl3.sub");
-# }
-#
-# BOOST_AUTO_TEST_CASE(getAs) {
-#     dafBase::PropertyList apl;
-#     apl.set("bool", true);
-#     apl.set("char", 'A');
-#     short s = 42;
-#     apl.set("short", s);
-#     apl.set("int", 2008);
-#     apl.set("int64_t", 0xfeeddeadbeefLL);
-#     float f = 3.14159;
-#     apl.set("float", f);
-#     double d = 2.718281828459045;
-#     apl.set("double", d);
-#     apl.set<std::string>("char*", "foo");
-#     apl.set("char*2", "foo2");
-#     apl.set("string", std::string("bar"));
-#     dafBase::PropertyList::Ptr aplp(new
-#     dafBase::PropertyList);
-#     aplp->set("bottom", "x");
-#     apl.set("top", aplp);
-#
-#     BOOST_CHECK_EQUAL(apl.getAsBool("bool"), true);
-#     BOOST_CHECK_THROW(apl.getAsBool("char"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("bool"), 1);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("char"), static_cast<int>('A'));
-#     BOOST_CHECK_EQUAL(apl.getAsInt("short"), 42);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("int"), 2008);
-#     BOOST_CHECK_THROW(apl.getAsInt("int64_t"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(apl.getAsInt64("bool"), 1LL);
-#     BOOST_CHECK_EQUAL(apl.getAsInt64("char"), static_cast<int64_t>('A'));
-#     BOOST_CHECK_EQUAL(apl.getAsInt64("short"), 42LL);
-#     BOOST_CHECK_EQUAL(apl.getAsInt64("int"), 2008LL);
-#     BOOST_CHECK_EQUAL(apl.getAsInt64("int64_t"), 0xfeeddeadbeefLL);
-#     BOOST_CHECK_THROW(apl.getAsInt64("float"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("bool"), 1.0);
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("char"), static_cast<double>('A'));
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("short"), 42.0);
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("int"), 2008.0);
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("int64_t"),
-#                       static_cast<double>(0xfeeddeadbeefLL));
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("float"), 3.14159f);
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("double"), 2.718281828459045);
-#     BOOST_CHECK_THROW(apl.getAsDouble("char*"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(apl.getAsString("char"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(apl.getAsString("char*"), "foo");
-#     BOOST_CHECK_EQUAL(apl.getAsString("char*2"), "foo2");
-#     BOOST_CHECK_EQUAL(apl.getAsString("string"), "bar");
-#     BOOST_CHECK_THROW(apl.getAsString("int"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(apl.getAsString("top.bottom"), "x");
-#     BOOST_CHECK_EQUAL(apl.getAsPropertyListPtr("top"), aplp);
-#     BOOST_CHECK_THROW(apl.getAsPropertyListPtr("top.bottom"),
-#                       boost::bad_any_cast);
-# }
-#
-# BOOST_AUTO_TEST_CASE(combine) {
-#     dafBase::PropertyList apl;
-#     apl.set("apl1.pre", 1);
-#     apl.set("apl1.post", 2);
-#     apl.set("int", 42);
-#     apl.set("double", 3.14);
-#     apl.set("apl2.plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#     apl.set("apl3.sub.subsub", "foo");
-#
-#     dafBase::PropertyList::Ptr aplp(new
-#     dafBase::PropertyList);
-#     aplp->set("apl1.pre", 3);
-#     aplp->add("apl1.pre", 4);
-#     aplp->set("int", 2008);
-#     aplp->set("apl2.foo", "bar");
-#     aplp->set("apl4.top", "bottom");
-#
-#     apl.combine(aplp);
-#
-#     BOOST_CHECK(apl.isPropertyListPtr("apl1"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl2"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl3"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl3.sub"));
-#     BOOST_CHECK(apl.isPropertyListPtr("apl4"));
-#     BOOST_CHECK(!apl.isArray("apl1"));
-#     BOOST_CHECK(apl.isArray("apl1.pre"));
-#     BOOST_CHECK(!apl.isArray("apl1.post"));
-#     BOOST_CHECK(!apl.isArray("apl2"));
-#     BOOST_CHECK(!apl.isArray("apl2.plus"));
-#     BOOST_CHECK(!apl.isArray("apl2.minus"));
-#     BOOST_CHECK(!apl.isArray("apl2.foo"));
-#     BOOST_CHECK(!apl.isArray("apl3"));
-#     BOOST_CHECK(!apl.isArray("apl3.sub"));
-#     BOOST_CHECK(!apl.isArray("apl3.subsub"));
-#     BOOST_CHECK(!apl.isArray("apl4"));
-#     BOOST_CHECK(!apl.isArray("apl4.top"));
-#     BOOST_CHECK(apl.isArray("int"));
-#     BOOST_CHECK(!apl.isArray("double"));
-#     BOOST_CHECK_EQUAL(apl.valueCount("apl1.pre"), 3U);
-#     BOOST_CHECK_EQUAL(apl.valueCount("int"), 2U);
-#     std::vector<int> v = apl.getArray<int>("apl1.pre");
-#     BOOST_CHECK_EQUAL(v[0], 1);
-#     BOOST_CHECK_EQUAL(v[1], 3);
-#     BOOST_CHECK_EQUAL(v[2], 4);
-#     v = apl.getArray<int>("int");
-#     BOOST_CHECK_EQUAL(v[0], 42);
-#     BOOST_CHECK_EQUAL(v[1], 2008);
-# }
-#
-# BOOST_AUTO_TEST_CASE(combineThrow) {
-#     dafBase::PropertyList apl;
-#     apl.set("int", 42);
-#
-#     dafBase::PropertyList::Ptr aplp(new
-#     dafBase::PropertyList);
-#     aplp->set("int", 3.14159);
-#
-#     BOOST_CHECK_THROW(apl.combine(aplp),
-#                       lsst::pex::exceptions::DomainError);
-# }
-#
-# BOOST_AUTO_TEST_CASE(remove) {
-#     dafBase::PropertyList apl;
-#     apl.set("int", 42);
-#     apl.set("double", 3.14159);
-#     apl.set("apl1.plus", 1);
-#     apl.set("apl1.minus", -1);
-#     apl.set("apl1.zero", 0);
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 6U);
-#
-#     apl.remove("int");
-#     BOOST_CHECK(!apl.exists("int"));
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("apl1.plus"), 1);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("apl1.minus"), -1);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("apl1.zero"), 0);
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 5U);
-#
-#     apl.remove("apl1.zero");
-#     BOOST_CHECK(!apl.exists("int"));
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK(!apl.exists("apl1.zero"));
-#     BOOST_CHECK_EQUAL(apl.getAsInt("apl1.plus"), 1);
-#     BOOST_CHECK_EQUAL(apl.getAsInt("apl1.minus"), -1);
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 4U);
-#
-#     apl.remove("apl1");
-#     BOOST_CHECK(!apl.exists("int"));
-#     BOOST_CHECK_EQUAL(apl.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK(!apl.exists("apl1"));
-#     BOOST_CHECK(!apl.exists("apl1.plus"));
-#     BOOST_CHECK(!apl.exists("apl1.minus"));
-#     BOOST_CHECK(!apl.exists("apl1.zero"));
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 1U);
-#
-#     apl.remove("double");
-#     BOOST_CHECK(!apl.exists("int"));
-#     BOOST_CHECK(!apl.exists("double"));
-#     BOOST_CHECK(!apl.exists("apl1"));
-#     BOOST_CHECK(!apl.exists("apl1.plus"));
-#     BOOST_CHECK(!apl.exists("apl1.minus"));
-#     BOOST_CHECK(!apl.exists("apl1.zero"));
-#     BOOST_CHECK_EQUAL(apl.nameCount(false), 0U);
-# }
-#
-# BOOST_AUTO_TEST_CASE(deepCopy) {
-#     dafBase::PropertyList apl;
-#     apl.set("int", 42);
-#     dafBase::PropertyList::Ptr aplp(new
-#     dafBase::PropertyList);
-#     aplp->set("bottom", "x");
-#     apl.set("top", aplp);
-#
-#     dafBase::PropertyList::Ptr aplp2 = apl.deepCopy();
-#     BOOST_CHECK(aplp2->exists("int"));
-#     BOOST_CHECK(aplp2->exists("top.bottom"));
-#     BOOST_CHECK_EQUAL(aplp2->getAsInt("int"), 42);
-#     BOOST_CHECK_EQUAL(aplp2->getAsString("top.bottom"), "x");
-#     // Make sure it was indeed a deep copy.
-#     BOOST_CHECK(aplp2->getAsPropertyListPtr("top") != aplp);
-#     apl.set("int", 2008);
-#     apl.set("top.bottom", "y");
-#     BOOST_CHECK_EQUAL(apl.getAsInt("int"), 2008);
-#     BOOST_CHECK_EQUAL(apl.getAsString("top.bottom"), "y");
-#     BOOST_CHECK_EQUAL(aplp->getAsString("bottom"), "y");
-#     BOOST_CHECK_EQUAL(aplp2->getAsInt("int"), 42);
-#     BOOST_CHECK_EQUAL(aplp2->getAsString("top.bottom"), "x");
-# }
-#
-# BOOST_AUTO_TEST_CASE(toString) {
-#     dafBase::PropertyList apl;
-#     apl.set("bool", true);
-#     apl.set("char", '*');
-#     short s = 42;
-#     apl.set("short", s);
-#     apl.set("int", 2008);
-#     apl.set("int64_t", 0xfeeddeadbeefLL);
-#     float f = 3.14159;
-#     apl.set("float", f);
-#     double d = 2.718281828459045;
-#     apl.set("double", d);
-#     apl.set<std::string>("char*", "foo");
-#     apl.set("char*2", "foo2");
-#     apl.set("string", std::string("bar"));
-#     apl.set("apl1.pre", 1);
-#     apl.set("apl1.post", 2);
-#     apl.set("apl2.plus", 10.24);
-#     apl.set("apl2.minus", -10.24);
-#     apl.set("apl3.sub.subsub", "foo");
-#     apl.add("v", 10);
-#     apl.add("v", 9);
-#     apl.add("v", 8);
-#
-#     BOOST_CHECK_EQUAL(apl.toString(),
-#         "bool = 1\n"
-#         "char = '*'\n"
-#         "char* = \"foo\"\n"
-#         "char*2 = \"foo2\"\n"
-#         "double = 2.71828\n"
-#         "float = 3.14159\n"
-#         "int = 2008\n"
-#         "int64_t = 280297596632815\n"
-#         "apl1 = {\n"
-#         "..post = 2\n"
-#         "..pre = 1\n"
-#         "}\n"
-#         "apl2 = {\n"
-#         "..minus = -10.24\n"
-#         "..plus = 10.24\n"
-#         "}\n"
-#         "apl3 = {\n"
-#         "..sub = {\n"
-#         "....subsub = \"foo\"\n"
-#         "..}\n"
-#         "}\n"
-#         "short = 42\n"
-#         "string = \"bar\"\n"
-#         "v = [ 10, 9, 8 ]\n"
-#         );
-#     BOOST_CHECK_EQUAL(apl.toString(true),
-#         "bool = 1\n"
-#         "char = '*'\n"
-#         "char* = \"foo\"\n"
-#         "char*2 = \"foo2\"\n"
-#         "double = 2.71828\n"
-#         "float = 3.14159\n"
-#         "int = 2008\n"
-#         "int64_t = 280297596632815\n"
-#         "apl1 = { ... }\n"
-#         "apl2 = { ... }\n"
-#         "apl3 = { ... }\n"
-#         "short = 42\n"
-#         "string = \"bar\"\n"
-#         "v = [ 10, 9, 8 ]\n"
-#         );
-# }

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -42,14 +42,7 @@ class PropertyListTestCase(unittest.TestCase):
 
     def checkPickle(self, original):
         new = pickle.loads(pickle.dumps(original, 2))
-        self.assertEqual(original.nameCount(), new.nameCount())
-        self.assertEqual(original.getOrderedNames(), new.getOrderedNames())
-        for name in original.getOrderedNames():
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(original.get(name), new.get(name))
-            self.assertEqual(original.getArray(name), new.getArray(name))
-            self.assertEqual(original.getScalar(name), new.getScalar(name))
-            self.assertEqual(original.typeOf(name), new.typeOf(name))
+        self.assertEqual(new, original)
 
     def testScalar(self):
         apl = dafBase.PropertyList()

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -28,6 +28,7 @@ import numpy as np
 
 import lsst.utils.tests
 import lsst.daf.base as dafBase
+import lsst.pex.exceptions as pexExcept
 
 
 class PropertySetTestCase(unittest.TestCase):
@@ -389,10 +390,7 @@ class FlatTestCase(unittest.TestCase):
         ps.setInt("ints", v)
         ps.setInt("ints2", [10, 9, 8])
         w = ps.getArrayInt("ints")
-        self.assertEqual(len(w), 3)
-        self.assertEqual(v[0], w[0])
-        self.assertEqual(v[1], w[1])
-        self.assertEqual(v[2], w[2])
+        self.assertEqual(w, v)
         self.assertEqual(ps.getInt("ints2"), 8)
         self.assertEqual(ps.getArrayInt("ints2"), [10, 9, 8])
 
@@ -559,6 +557,356 @@ class FlatTestCase(unittest.TestCase):
         self.assertIsInstance(d2["ints"][0], (int, int))
         self.assertEqual(d2["ints"], [10, 9, 8])
 
+    def testAddVector(self):
+        ps = dafBase.PropertySet()
+        v = [42, 2008, 1]
+        ps.set("ints", v)
+
+        vv = [-42, -2008, -1]
+        ps.add("ints", vv)
+
+        w = ps.getArray("ints")
+        self.assertEqual(w, v + vv)
+
+    def testArrayProperties(self):
+        ps = dafBase.PropertySet()
+        v = [42, 2008, 1]
+        ps.set("ints", v)
+        ps.set("int", 365)
+        ps.set("ints2", -42)
+        ps.add("ints2", -2008)
+
+        self.assertTrue(ps.isArray("ints"))
+        self.assertFalse(ps.isArray("int"))
+        self.assertTrue(ps.isArray("ints2"))
+        self.assertEqual(ps.valueCount("ints"), 3)
+        self.assertEqual(ps.valueCount("int"), 1)
+        self.assertEqual(ps.valueCount("ints2"), 2)
+        self.assertEqual(ps.typeOf("ints"), dafBase.PropertySet.TYPE_Int)
+        self.assertEqual(ps.typeOf("int"), dafBase.PropertySet.TYPE_Int)
+        self.assertEqual(ps.typeOf("ints2"), dafBase.PropertySet.TYPE_Int)
+
+    def testHierarchy(self):
+        ps = dafBase.PropertySet()
+        psp = dafBase.PropertySet()
+
+        psp.set("pre", 1)
+        ps.set("ps1", psp)
+        psp.set("post", 2)
+        ps.set("int", 42)
+        ps.set("ps2", dafBase.PropertySet())
+        ps.getPropertySet("ps2").set("plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+        ps.set("ps3.sub1", "foo")
+        ps.set("ps3.sub2", "bar")
+
+        self.assertTrue(ps.exists("ps1"))
+        self.assertTrue(ps.exists("ps2"))
+        self.assertTrue(ps.exists("ps3"))
+        self.assertTrue(ps.exists("ps1.pre"))
+        self.assertTrue(ps.exists("ps1.post"))
+        self.assertTrue(ps.exists("ps2.plus"))
+        self.assertTrue(ps.exists("ps2.minus"))
+        self.assertTrue(ps.exists("ps3.sub1"))
+        self.assertTrue(ps.exists("ps3.sub2"))
+
+        self.assertTrue(ps.isPropertySetPtr("ps1"))
+        self.assertTrue(ps.isPropertySetPtr("ps2"))
+        self.assertTrue(ps.isPropertySetPtr("ps3"))
+        self.assertFalse(ps.isPropertySetPtr("int"))
+        self.assertFalse(ps.isPropertySetPtr("ps1.pre"))
+        self.assertFalse(ps.isPropertySetPtr("ps1.post"))
+        self.assertFalse(ps.isPropertySetPtr("ps2.plus"))
+        self.assertFalse(ps.isPropertySetPtr("ps2.minus"))
+        self.assertFalse(ps.isPropertySetPtr("ps3.sub1"))
+        self.assertFalse(ps.isPropertySetPtr("ps3.sub2"))
+
+        psp1 = ps.getPropertySet("ps1")
+        psp2 = ps.getPropertySet("ps2")
+        psp3 = ps.getPropertySet("ps3")
+        self.assertIsInstance(psp1, dafBase.PropertySet)
+        self.assertIsInstance(psp2, dafBase.PropertySet)
+        self.assertIsInstance(psp3, dafBase.PropertySet)
+        self.assertEqual(psp1, psp)
+        self.assertTrue(psp1.exists("pre"))
+        self.assertTrue(psp1.exists("post"))
+        self.assertTrue(psp2.exists("plus"))
+        self.assertTrue(psp2.exists("minus"))
+        self.assertTrue(psp3.exists("sub1"))
+        self.assertTrue(psp3.exists("sub2"))
+        self.assertEqual(psp1.getAsInt("pre"), 1)
+        self.assertEqual(psp1.getAsInt("post"), 2)
+        self.assertEqual(psp2.getAsDouble("plus"), 10.24)
+        self.assertEqual(psp2.getAsDouble("minus"), -10.24)
+        self.assertEqual(psp3.getAsString("sub1"), "foo")
+        self.assertEqual(psp3.getAsString("sub2"), "bar")
+
+        # Make sure checking a subproperty doesn't create it.
+        self.assertFalse(ps.exists("ps2.pre"))
+        self.assertFalse(ps.exists("ps2.pre"))
+        # Make sure checking an element doesn't create it.
+        self.assertFalse(ps.exists("ps4"))
+        self.assertFalse(ps.exists("ps4"))
+        # Make sure checking a subproperty with a nonexistent parent doesn't
+        # create it.
+        self.assertFalse(ps.exists("ps4.sub"))
+        self.assertFalse(ps.exists("ps4.sub"))
+        # Make sure checking a subproperty doesn't create its parent.
+        self.assertFalse(ps.exists("ps4"))
+
+#
+    def testvariousThrows(self):
+        ps = dafBase.PropertySet()
+        ps.set("int", 42)
+        with self.assertRaises(pexExcept.InvalidParameterError):
+            ps.set("int.sub", "foo")
+        with self.assertRaises(TypeError):
+            ps.getDouble("int")
+        with self.assertRaises(LookupError):
+            ps.getDouble("double")
+        with self.assertRaises(KeyError):
+            ps.getArray("double")
+        with self.assertRaises(LookupError):
+            ps.typeOf("double")
+        with self.assertRaises(TypeError):
+            ps.add("int", 4.2)
+
+        v = [3.14159, 2.71828]
+        with self.assertRaises(TypeError):
+            ps.add("int", v)
+        ps.remove("foo.bar")
+        ps.remove("int.sub")
+
+    def testNames(self):
+        ps = dafBase.PropertySet()
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("int", 42)
+        ps.set("double", 3.14)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+
+        self.assertEqual(ps.nameCount(), 4)
+        self.assertEqual(ps.nameCount(False), 8)
+
+        v = set(ps.names())
+        self.assertEqual(len(v), 4)
+        self.assertEqual(v, {"double", "int", "ps1", "ps2"})
+        v = set(ps.names(False))
+        self.assertEqual(len(v), 8)
+        self.assertEqual(v, {"double", "int", "ps1", "ps1.post",
+                             "ps1.pre", "ps2", "ps2.minus", "ps2.plus"})
+
+    def testParamNames(self):
+        ps = dafBase.PropertySet()
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("int", 42)
+        ps.set("double", 3.14)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+
+        v = set(ps.paramNames())
+        self.assertEqual(len(v), 2)
+        self.assertEqual(v, {"double", "int"})
+        v = set(ps.paramNames(False))
+        self.assertEqual(len(v), 6)
+        self.assertEqual(v, {"double", "int", "ps1.post", "ps1.pre",
+                             "ps2.minus", "ps2.plus"})
+
+    def testPropertySetNames(self):
+        ps = dafBase.PropertySet()
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("int", 42)
+        ps.set("double", 3.14)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+        ps.set("ps3.sub.subsub", "foo")
+
+        v = set(ps.propertySetNames())
+        self.assertEqual(len(v), 3)
+        self.assertEqual(v, {"ps1", "ps2", "ps3"})
+        v = set(ps.propertySetNames(False))
+        self.assertEqual(len(v), 4)
+        self.assertEqual(v, {"ps1", "ps2", "ps3", "ps3.sub"})
+
+    def testGetAs(self):
+        ps = dafBase.PropertySet()
+        ps.set("bool", True)
+        ps.setShort("short", 42)
+        ps.set("int", 2008)
+        ps.set("int64_t", 0xfeeddeadbeef)
+        f = 3.14159
+        ps.setFloat("float", f)
+        d = 2.718281828459045
+        ps.setDouble("double", d)
+        ps.setString("char*", "foo")
+        ps.set("char*2", "foo2")
+        ps.set("string", "bar")
+        psp = dafBase.PropertySet()
+        psp.set("bottom", "x")
+        ps.set("top", psp)
+
+        self.assertIs(ps.getAsBool("bool"), True)
+        self.assertEqual(ps.getAsInt("bool"), 1)
+        self.assertEqual(ps.getAsInt("short"), 42)
+        self.assertEqual(ps.getAsInt("int"), 2008)
+        with self.assertRaises(TypeError):
+            ps.getAsInt("int64_t")
+        self.assertEqual(ps.getAsInt64("bool"), 1)
+        self.assertEqual(ps.getAsInt64("short"), 42)
+        self.assertEqual(ps.getAsInt64("int"), 2008)
+        self.assertEqual(ps.getAsInt64("int64_t"), 0xfeeddeadbeef)
+        with self.assertRaises(TypeError):
+            ps.getAsInt64("float")
+        self.assertEqual(ps.getAsDouble("bool"), 1.0)
+        self.assertEqual(ps.getAsDouble("short"), 42.0)
+        self.assertEqual(ps.getAsDouble("int"), 2008.0)
+        self.assertEqual(ps.getAsDouble("int64_t"),
+                         float(0xfeeddeadbeef))
+        self.assertAlmostEqual(ps.getAsDouble("float"), 3.14159, places=5)
+        self.assertAlmostEqual(ps.getAsDouble("double"), 2.718281828459045, places=15)
+        with self.assertRaises(TypeError):
+            ps.getAsDouble("char*")
+        self.assertEqual(ps.getAsString("char*"), "foo")
+        self.assertEqual(ps.getAsString("char*2"), "foo2")
+        self.assertEqual(ps.getAsString("string"), "bar")
+        with self.assertRaises(TypeError):
+            ps.getAsString("int")
+        self.assertEqual(ps.getAsString("top.bottom"), "x")
+        self.assertEqual(ps.getAsPropertySetPtr("top"), psp)
+        with self.assertRaises(TypeError):
+            ps.getAsPropertySetPtr("top.bottom")
+
+    def testRemove(self):
+        ps = dafBase.PropertySet()
+        ps.set("int", 42)
+        ps.set("double", 3.14159)
+        ps.set("ps1.plus", 1)
+        ps.set("ps1.minus", -1)
+        ps.set("ps1.zero", 0)
+        self.assertEqual(ps.nameCount(False), 6)
+
+        ps.remove("int")
+        self.assertFalse(ps.exists("int"))
+        self.assertEqual(ps.getAsDouble("double"), 3.14159)
+        self.assertEqual(ps.getAsInt("ps1.plus"), 1)
+        self.assertEqual(ps.getAsInt("ps1.minus"), -1)
+        self.assertEqual(ps.getAsInt("ps1.zero"), 0)
+        self.assertEqual(ps.nameCount(False), 5)
+
+        ps.remove("ps1.zero")
+        self.assertFalse(ps.exists("int"))
+        self.assertEqual(ps.getAsDouble("double"), 3.14159)
+        self.assertFalse(ps.exists("ps1.zero"))
+        self.assertEqual(ps.getAsInt("ps1.plus"), 1)
+        self.assertEqual(ps.getAsInt("ps1.minus"), -1)
+        self.assertEqual(ps.nameCount(False), 4)
+
+        ps.remove("ps1")
+        self.assertFalse(ps.exists("int"))
+        self.assertEqual(ps.getAsDouble("double"), 3.14159)
+        self.assertFalse(ps.exists("ps1"))
+        self.assertFalse(ps.exists("ps1.plus"))
+        self.assertFalse(ps.exists("ps1.minus"))
+        self.assertFalse(ps.exists("ps1.zero"))
+        self.assertEqual(ps.nameCount(False), 1)
+
+        ps.remove("double")
+        self.assertFalse(ps.exists("int"))
+        self.assertFalse(ps.exists("double"))
+        self.assertFalse(ps.exists("ps1"))
+        self.assertFalse(ps.exists("ps1.plus"))
+        self.assertFalse(ps.exists("ps1.minus"))
+        self.assertFalse(ps.exists("ps1.zero"))
+        self.assertEqual(ps.nameCount(False), 0)
+
+    def testDeepCopy(self):
+        ps = dafBase.PropertySet()
+        ps.set("int", 42)
+        psp = dafBase.PropertySet()
+        psp.set("bottom", "x")
+        ps.set("top", psp)
+
+        psp2 = ps.deepCopy()
+        self.assertTrue(psp2.exists("int"))
+        self.assertTrue(psp2.exists("top.bottom"))
+        self.assertEqual(psp2.getAsInt("int"), 42)
+        self.assertEqual(psp2.getAsString("top.bottom"), "x")
+        # Make sure it was indeed a deep copy.
+        ps.set("int", 2008)
+        ps.set("top.bottom", "y")
+        self.assertEqual(ps.getAsInt("int"), 2008)
+        self.assertEqual(ps.getAsString("top.bottom"), "y")
+        self.assertEqual(psp.getAsString("bottom"), "y")
+        self.assertEqual(psp2.getAsInt("int"), 42)
+        self.assertEqual(psp2.getAsString("top.bottom"), "x")
+
+    def testToString(self):
+        ps = dafBase.PropertySet()
+        ps.set("bool", True)
+        s = 42
+        ps.setShort("short", s)
+        ps.set("int", 2008)
+        ps.set("int64_t", 0xfeeddeadbeef)
+        f = 3.14159
+        ps.setFloat("float", f)
+        d = 2.718281828459045
+        ps.setDouble("double", d)
+        ps.setString("char*", "foo")
+        ps.set("char*2", "foo2")
+        ps.set("string", "bar")
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+        ps.set("ps3.sub.subsub", "foo")
+        ps.add("v", 10)
+        ps.add("v", 9)
+        ps.add("v", 8)
+
+        self.assertEqual(ps.toString(),
+                         "bool = 1\n"
+                         "char* = \"foo\"\n"
+                         "char*2 = \"foo2\"\n"
+                         "double = 2.7182818284590\n"
+                         "float = 3.141590\n"
+                         "int = 2008\n"
+                         "int64_t = 280297596632815\n"
+                         "ps1 = {\n"
+                         "..post = 2\n"
+                         "..pre = 1\n"
+                         "}\n"
+                         "ps2 = {\n"
+                         "..minus = -10.240000000000\n"
+                         "..plus = 10.240000000000\n"
+                         "}\n"
+                         "ps3 = {\n"
+                         "..sub = {\n"
+                         "....subsub = \"foo\"\n"
+                         "..}\n"
+                         "}\n"
+                         "short = 42\n"
+                         "string = \"bar\"\n"
+                         "v = [ 10, 9, 8 ]\n"
+                         )
+        self.assertEqual(ps.toString(True),
+                         "bool = 1\n"
+                         "char* = \"foo\"\n"
+                         "char*2 = \"foo2\"\n"
+                         "double = 2.7182818284590\n"
+                         "float = 3.141590\n"
+                         "int = 2008\n"
+                         "int64_t = 280297596632815\n"
+                         "ps1 = { ... }\n"
+                         "ps2 = { ... }\n"
+                         "ps3 = { ... }\n"
+                         "short = 42\n"
+                         "string = \"bar\"\n"
+                         "v = [ 10, 9, 8 ]\n"
+                         )
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
@@ -571,436 +919,3 @@ def setup_module(module):
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()
-
-
-# BOOST_AUTO_TEST_CASE(getScalarThrow) {
-#     dafBase::PropertySet ps;
-#     ps.set("bool", true);
-#     short s = 42;
-#     ps.set("short", s);
-#     ps.set("int", 2008);
-#     ps.set("int64_t", 0xfeeddeadbeefLL);
-#     float f = 3.14159;
-#     ps.set("float", f);
-#     double d = 2.718281828459045;
-#     ps.set("double", d);
-#     ps.set<std::string>("char*", "foo");
-#     ps.set("char*2", "foo2");
-#     ps.set("string", std::string("bar"));
-#
-#     BOOST_CHECK_THROW(ps.get<bool>("short"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<bool>("int"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<short>("int"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<int>("short"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<int>("bool"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<unsigned int>("int"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<double>("float"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<float>("double"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<std::string>("int"), boost::bad_any_cast);
-# }
-#
-#
-# BOOST_AUTO_TEST_CASE(addVector) {
-#     dafBase::PropertySet ps;
-#     std::vector<int> v;
-#     v.push_back(42);
-#     v.push_back(2008);
-#     v.push_back(1);
-#     ps.set("ints", v);
-#
-#     std::vector<int> vv;
-#     vv.push_back(-42);
-#     vv.push_back(-2008);
-#     vv.push_back(-1);
-#     ps.add("ints", vv);
-#
-#     std::vector<int> w = ps.getArray<int>("ints");
-#     BOOST_CHECK_EQUAL(w.size(), 6U);
-#     for (int i = 0; i < 3; ++i) {
-#         BOOST_CHECK_EQUAL(v[i], w[i]);
-#         BOOST_CHECK_EQUAL(vv[i], w[i + 3]);
-#     }
-# }
-#
-# BOOST_AUTO_TEST_CASE(arrayProperties) {
-#     dafBase::PropertySet ps;
-#     std::vector<int> v;
-#     v.push_back(42);
-#     v.push_back(2008);
-#     v.push_back(1);
-#     ps.set("ints", v);
-#     ps.set("int", 365);
-#     ps.set("ints2", -42);
-#     ps.add("ints2", -2008);
-#
-#     BOOST_CHECK_EQUAL(ps.isArray("ints"), true);
-#     BOOST_CHECK_EQUAL(ps.isArray("int"), false);
-#     BOOST_CHECK_EQUAL(ps.isArray("ints2"), true);
-#     BOOST_CHECK_EQUAL(ps.valueCount("ints"), 3U);
-#     BOOST_CHECK_EQUAL(ps.valueCount("int"), 1U);
-#     BOOST_CHECK_EQUAL(ps.valueCount("ints2"), 2U);
-#     BOOST_CHECK(ps.typeOf("ints") == typeid(int));
-#     BOOST_CHECK(ps.typeOf("int") == typeid(int));
-#     BOOST_CHECK(ps.typeOf("ints2") == typeid(int));
-# }
-#
-# BOOST_AUTO_TEST_CASE(hierarchy) {
-#     dafBase::PropertySet ps;
-#     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-#
-#     psp->set("pre", 1);
-#     ps.set("ps1", psp);
-#     psp->set("post", 2);
-#     ps.set("int", 42);
-#     ps.set("ps2", dafBase::PropertySet::Ptr(new dafBase::PropertySet));
-#     ps.get<dafBase::PropertySet::Ptr>("ps2")->set("plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#     ps.set("ps3.sub1", "foo");
-#     ps.set("ps3.sub2", "bar");
-#
-#     BOOST_CHECK(ps.exists("ps1"));
-#     BOOST_CHECK(ps.exists("ps2"));
-#     BOOST_CHECK(ps.exists("ps3"));
-#     BOOST_CHECK(ps.exists("ps1.pre"));
-#     BOOST_CHECK(ps.exists("ps1.post"));
-#     BOOST_CHECK(ps.exists("ps2.plus"));
-#     BOOST_CHECK(ps.exists("ps2.minus"));
-#     BOOST_CHECK(ps.exists("ps3.sub1"));
-#     BOOST_CHECK(ps.exists("ps3.sub2"));
-#
-#     BOOST_CHECK(ps.isPropertySetPtr("ps1"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps2"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps3"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("int"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps1.pre"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps1.post"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps2.plus"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps2.minus"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps3.sub1"));
-#     BOOST_CHECK(!ps.isPropertySetPtr("ps3.sub2"));
-#
-#     dafBase::PropertySet::Ptr psp1 = ps.get<dafBase::PropertySet::Ptr>("ps1");
-#     dafBase::PropertySet::Ptr psp2 = ps.get<dafBase::PropertySet::Ptr>("ps2");
-#     dafBase::PropertySet::Ptr psp3 = ps.get<dafBase::PropertySet::Ptr>("ps3");
-#     BOOST_CHECK(psp1);
-#     BOOST_CHECK(psp2);
-#     BOOST_CHECK(psp3);
-#     BOOST_CHECK(psp1 == psp);
-#     BOOST_CHECK(psp1->exists("pre"));
-#     BOOST_CHECK(psp1->exists("post"));
-#     BOOST_CHECK(psp2->exists("plus"));
-#     BOOST_CHECK(psp2->exists("minus"));
-#     BOOST_CHECK(psp3->exists("sub1"));
-#     BOOST_CHECK(psp3->exists("sub2"));
-#     BOOST_CHECK_EQUAL(psp1->get<int>("pre"), 1);
-#     BOOST_CHECK_EQUAL(psp1->get<int>("post"), 2);
-#     BOOST_CHECK_EQUAL(psp2->get<double>("plus"), 10.24);
-#     BOOST_CHECK_EQUAL(psp2->get<double>("minus"), -10.24);
-#     BOOST_CHECK_EQUAL(psp3->get<std::string>("sub1"), "foo");
-#     BOOST_CHECK_EQUAL(psp3->get<std::string>("sub2"), "bar");
-#
-#     // Make sure checking a subproperty doesn't create it.
-#     BOOST_CHECK(!ps.exists("ps2.pre"));
-#     BOOST_CHECK(!ps.exists("ps2.pre"));
-#     // Make sure checking an element doesn't create it.
-#     BOOST_CHECK(!ps.exists("ps4"));
-#     BOOST_CHECK(!ps.exists("ps4"));
-#     // Make sure checking a subproperty with a nonexistent parent doesn't
-#     // create it.
-#     BOOST_CHECK(!ps.exists("ps4.sub"));
-#     BOOST_CHECK(!ps.exists("ps4.sub"));
-#     // Make sure checking a subproperty doesn't create its parent.
-#     BOOST_CHECK(!ps.exists("ps4"));
-# }
-#
-# BOOST_AUTO_TEST_CASE(variousThrows) {
-#     dafBase::PropertySet ps;
-#     ps.set("int", 42);
-#     BOOST_CHECK_THROW(ps.set("int.sub", "foo"),
-#                       lsst::pex::exceptions::InvalidParameterError);
-#     BOOST_CHECK_THROW(ps.get<double>("int"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.get<double>("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(ps.getArray<double>("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(ps.typeOf("double"),
-#                       lsst::pex::exceptions::NotFoundError);
-#     BOOST_CHECK_THROW(ps.add("int", 4.2),
-#                       lsst::pex::exceptions::DomainError);
-#     std::vector<double> v;
-#     v.push_back(3.14159);
-#     v.push_back(2.71828);
-#     BOOST_CHECK_THROW(ps.add("int", v),
-#                       lsst::pex::exceptions::DomainError);
-#     BOOST_CHECK_NO_THROW(ps.remove("foo.bar"));
-#     BOOST_CHECK_NO_THROW(ps.remove("int.sub"));
-# }
-#
-# BOOST_AUTO_TEST_CASE(names) {
-#     dafBase::PropertySet ps;
-#     ps.set("ps1.pre", 1);
-#     ps.set("ps1.post", 2);
-#     ps.set("int", 42);
-#     ps.set("double", 3.14);
-#     ps.set("ps2.plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#
-#     BOOST_CHECK_EQUAL(ps.nameCount(), 4U);
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 8U);
-#
-#     std::vector<std::string> v = ps.names();
-#     BOOST_CHECK_EQUAL(v.size(), 4U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "ps1");
-#     BOOST_CHECK_EQUAL(v[3], "ps2");
-#     v = ps.names(false);
-#     BOOST_CHECK_EQUAL(v.size(), 8U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "ps1");
-#     BOOST_CHECK_EQUAL(v[3], "ps1.post");
-#     BOOST_CHECK_EQUAL(v[4], "ps1.pre");
-#     BOOST_CHECK_EQUAL(v[5], "ps2");
-#     BOOST_CHECK_EQUAL(v[6], "ps2.minus");
-#     BOOST_CHECK_EQUAL(v[7], "ps2.plus");
-# }
-#
-# BOOST_AUTO_TEST_CASE(paramNames) {
-#     dafBase::PropertySet ps;
-#     ps.set("ps1.pre", 1);
-#     ps.set("ps1.post", 2);
-#     ps.set("int", 42);
-#     ps.set("double", 3.14);
-#     ps.set("ps2.plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#
-#     std::vector<std::string> v = ps.paramNames();
-#     BOOST_CHECK_EQUAL(v.size(), 2U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     v = ps.paramNames(false);
-#     BOOST_CHECK_EQUAL(v.size(), 6U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "double");
-#     BOOST_CHECK_EQUAL(v[1], "int");
-#     BOOST_CHECK_EQUAL(v[2], "ps1.post");
-#     BOOST_CHECK_EQUAL(v[3], "ps1.pre");
-#     BOOST_CHECK_EQUAL(v[4], "ps2.minus");
-#     BOOST_CHECK_EQUAL(v[5], "ps2.plus");
-# }
-#
-# BOOST_AUTO_TEST_CASE(propertySetNames) {
-#     dafBase::PropertySet ps;
-#     ps.set("ps1.pre", 1);
-#     ps.set("ps1.post", 2);
-#     ps.set("int", 42);
-#     ps.set("double", 3.14);
-#     ps.set("ps2.plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#     ps.set("ps3.sub.subsub", "foo");
-#
-#     std::vector<std::string> v = ps.propertySetNames();
-#     BOOST_CHECK_EQUAL(v.size(), 3U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "ps1");
-#     BOOST_CHECK_EQUAL(v[1], "ps2");
-#     BOOST_CHECK_EQUAL(v[2], "ps3");
-#     v = ps.propertySetNames(false);
-#     BOOST_CHECK_EQUAL(v.size(), 4U);
-#     std::sort(v.begin(), v.end());
-#     BOOST_CHECK_EQUAL(v[0], "ps1");
-#     BOOST_CHECK_EQUAL(v[1], "ps2");
-#     BOOST_CHECK_EQUAL(v[2], "ps3");
-#     BOOST_CHECK_EQUAL(v[3], "ps3.sub");
-# }
-#
-# BOOST_AUTO_TEST_CASE(getAs) {
-#     dafBase::PropertySet ps;
-#     ps.set("bool", true);
-#     ps.set("char", 'A');
-#     short s = 42;
-#     ps.set("short", s);
-#     ps.set("int", 2008);
-#     ps.set("int64_t", 0xfeeddeadbeefLL);
-#     float f = 3.14159;
-#     ps.set("float", f);
-#     double d = 2.718281828459045;
-#     ps.set("double", d);
-#     ps.set<std::string>("char*", "foo");
-#     ps.set("char*2", "foo2");
-#     ps.set("string", std::string("bar"));
-#     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-#     psp->set("bottom", "x");
-#     ps.set("top", psp);
-#
-#     BOOST_CHECK_EQUAL(ps.getAsBool("bool"), true);
-#     BOOST_CHECK_THROW(ps.getAsBool("char"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("bool"), 1);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("char"), static_cast<int>('A'));
-#     BOOST_CHECK_EQUAL(ps.getAsInt("short"), 42);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("int"), 2008);
-#     BOOST_CHECK_THROW(ps.getAsInt("int64_t"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(ps.getAsInt64("bool"), 1LL);
-#     BOOST_CHECK_EQUAL(ps.getAsInt64("char"), static_cast<int64_t>('A'));
-#     BOOST_CHECK_EQUAL(ps.getAsInt64("short"), 42LL);
-#     BOOST_CHECK_EQUAL(ps.getAsInt64("int"), 2008LL);
-#     BOOST_CHECK_EQUAL(ps.getAsInt64("int64_t"), 0xfeeddeadbeefLL);
-#     BOOST_CHECK_THROW(ps.getAsInt64("float"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("bool"), 1.0);
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("char"), static_cast<double>('A'));
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("short"), 42.0);
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("int"), 2008.0);
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("int64_t"),
-#                       static_cast<double>(0xfeeddeadbeefLL));
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("float"), 3.14159f);
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("double"), 2.718281828459045);
-#     BOOST_CHECK_THROW(ps.getAsDouble("char*"), boost::bad_any_cast);
-#     BOOST_CHECK_THROW(ps.getAsString("char"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(ps.getAsString("char*"), "foo");
-#     BOOST_CHECK_EQUAL(ps.getAsString("char*2"), "foo2");
-#     BOOST_CHECK_EQUAL(ps.getAsString("string"), "bar");
-#     BOOST_CHECK_THROW(ps.getAsString("int"), boost::bad_any_cast);
-#     BOOST_CHECK_EQUAL(ps.getAsString("top.bottom"), "x");
-#     BOOST_CHECK_EQUAL(ps.getAsPropertySetPtr("top"), psp);
-#     BOOST_CHECK_THROW(ps.getAsPropertySetPtr("top.bottom"),
-#                       boost::bad_any_cast);
-# }
-#
-# BOOST_AUTO_TEST_CASE(remove) {
-#     dafBase::PropertySet ps;
-#     ps.set("int", 42);
-#     ps.set("double", 3.14159);
-#     ps.set("ps1.plus", 1);
-#     ps.set("ps1.minus", -1);
-#     ps.set("ps1.zero", 0);
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 6U);
-#
-#     ps.remove("int");
-#     BOOST_CHECK(!ps.exists("int"));
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("ps1.plus"), 1);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("ps1.minus"), -1);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("ps1.zero"), 0);
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 5U);
-#
-#     ps.remove("ps1.zero");
-#     BOOST_CHECK(!ps.exists("int"));
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK(!ps.exists("ps1.zero"));
-#     BOOST_CHECK_EQUAL(ps.getAsInt("ps1.plus"), 1);
-#     BOOST_CHECK_EQUAL(ps.getAsInt("ps1.minus"), -1);
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 4U);
-#
-#     ps.remove("ps1");
-#     BOOST_CHECK(!ps.exists("int"));
-#     BOOST_CHECK_EQUAL(ps.getAsDouble("double"), 3.14159);
-#     BOOST_CHECK(!ps.exists("ps1"));
-#     BOOST_CHECK(!ps.exists("ps1.plus"));
-#     BOOST_CHECK(!ps.exists("ps1.minus"));
-#     BOOST_CHECK(!ps.exists("ps1.zero"));
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 1U);
-#
-#     ps.remove("double");
-#     BOOST_CHECK(!ps.exists("int"));
-#     BOOST_CHECK(!ps.exists("double"));
-#     BOOST_CHECK(!ps.exists("ps1"));
-#     BOOST_CHECK(!ps.exists("ps1.plus"));
-#     BOOST_CHECK(!ps.exists("ps1.minus"));
-#     BOOST_CHECK(!ps.exists("ps1.zero"));
-#     BOOST_CHECK_EQUAL(ps.nameCount(false), 0U);
-# }
-#
-# BOOST_AUTO_TEST_CASE(deepCopy) {
-#     dafBase::PropertySet ps;
-#     ps.set("int", 42);
-#     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-#     psp->set("bottom", "x");
-#     ps.set("top", psp);
-#
-#     dafBase::PropertySet::Ptr psp2 = ps.deepCopy();
-#     BOOST_CHECK(psp2->exists("int"));
-#     BOOST_CHECK(psp2->exists("top.bottom"));
-#     BOOST_CHECK_EQUAL(psp2->getAsInt("int"), 42);
-#     BOOST_CHECK_EQUAL(psp2->getAsString("top.bottom"), "x");
-#     // Make sure it was indeed a deep copy.
-#     BOOST_CHECK(psp2->getAsPropertySetPtr("top") != psp);
-#     ps.set("int", 2008);
-#     ps.set("top.bottom", "y");
-#     BOOST_CHECK_EQUAL(ps.getAsInt("int"), 2008);
-#     BOOST_CHECK_EQUAL(ps.getAsString("top.bottom"), "y");
-#     BOOST_CHECK_EQUAL(psp->getAsString("bottom"), "y");
-#     BOOST_CHECK_EQUAL(psp2->getAsInt("int"), 42);
-#     BOOST_CHECK_EQUAL(psp2->getAsString("top.bottom"), "x");
-# }
-#
-# BOOST_AUTO_TEST_CASE(toString) {
-#     dafBase::PropertySet ps;
-#     ps.set("bool", true);
-#     ps.set("char", '*');
-#     short s = 42;
-#     ps.set("short", s);
-#     ps.set("int", 2008);
-#     ps.set("int64_t", 0xfeeddeadbeefLL);
-#     float f = 3.14159;
-#     ps.set("float", f);
-#     double d = 2.718281828459045;
-#     ps.set("double", d);
-#     ps.set<std::string>("char*", "foo");
-#     ps.set("char*2", "foo2");
-#     ps.set("string", std::string("bar"));
-#     ps.set("ps1.pre", 1);
-#     ps.set("ps1.post", 2);
-#     ps.set("ps2.plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#     ps.set("ps3.sub.subsub", "foo");
-#     ps.add("v", 10);
-#     ps.add("v", 9);
-#     ps.add("v", 8);
-#
-#     BOOST_CHECK_EQUAL(ps.toString(),
-#         "bool = 1\n"
-#         "char = '*'\n"
-#         "char* = \"foo\"\n"
-#         "char*2 = \"foo2\"\n"
-#         "double = 2.71828\n"
-#         "float = 3.14159\n"
-#         "int = 2008\n"
-#         "int64_t = 280297596632815\n"
-#         "ps1 = {\n"
-#         "..post = 2\n"
-#         "..pre = 1\n"
-#         "}\n"
-#         "ps2 = {\n"
-#         "..minus = -10.24\n"
-#         "..plus = 10.24\n"
-#         "}\n"
-#         "ps3 = {\n"
-#         "..sub = {\n"
-#         "....subsub = \"foo\"\n"
-#         "..}\n"
-#         "}\n"
-#         "short = 42\n"
-#         "string = \"bar\"\n"
-#         "v = [ 10, 9, 8 ]\n"
-#         );
-#     BOOST_CHECK_EQUAL(ps.toString(true),
-#         "bool = 1\n"
-#         "char = '*'\n"
-#         "char* = \"foo\"\n"
-#         "char*2 = \"foo2\"\n"
-#         "double = 2.71828\n"
-#         "float = 3.14159\n"
-#         "int = 2008\n"
-#         "int64_t = 280297596632815\n"
-#         "ps1 = { ... }\n"
-#         "ps2 = { ... }\n"
-#         "ps3 = { ... }\n"
-#         "short = 42\n"
-#         "string = \"bar\"\n"
-#         "v = [ 10, 9, 8 ]\n"
-#         );
-# }

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -28,7 +28,6 @@ import numpy as np
 
 import lsst.utils.tests
 import lsst.daf.base as dafBase
-import lsst.pex.exceptions as pexExcept
 
 
 class PropertySetTestCase(unittest.TestCase):
@@ -243,7 +242,7 @@ class PropertySetTestCase(unittest.TestCase):
         ps.setShort("short", 42)
         ps.setInt("int", 2008)
         with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(pexExcept.NotFoundError):
+            with self.assertRaises(KeyError):
                 ps.get("foo")
         self.checkPickle(ps)
 
@@ -432,7 +431,7 @@ class FlatTestCase(unittest.TestCase):
         ps.setShort("short", 42)
         ps.setInt("int", 2008)
         with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(pexExcept.NotFoundError):
+            with self.assertRaises(KeyError):
                 ps.get("foo")
 
     def testSubPS(self):

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -39,14 +39,7 @@ class PropertySetTestCase(unittest.TestCase):
 
     def checkPickle(self, original):
         new = pickle.loads(pickle.dumps(original, 4))
-        self.assertEqual(original.nameCount(), new.nameCount())
-        self.assertEqual(set(original.paramNames(False)), set(new.paramNames(False)))
-        for name in original.paramNames(False):
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(original.get(name), new.get(name))
-            self.assertEqual(original.getArray(name), new.getArray(name))
-            self.assertEqual(original.getScalar(name), new.getScalar(name))
-            self.assertEqual(original.typeOf(name), new.typeOf(name))
+        self.assertEqual(new, original)
 
     def testScalar(self):
         ps = dafBase.PropertySet()

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -454,6 +454,65 @@ class FlatTestCase(unittest.TestCase):
         self.assertEqual(ps.getScalar("b.c"), 20)
         self.assertEqual(ps.exists("b"), False)
 
+    def testCombine(self):
+        ps = dafBase.PropertySet()
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("int", 42)
+        ps.set("double", 3.14)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+        ps.set("ps3.sub.subsub", "foo")
+
+        psp = dafBase.PropertySet()
+        psp.set("ps1.pre", 3)
+        psp.add("ps1.pre", 4)
+        psp.set("int", 2008)
+        psp.set("ps2.foo", "bar")
+        psp.set("ps4.top", "bottom")
+
+        ps.combine(psp)
+
+        self.assertIsInstance(ps.getScalar("ps1"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps2"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps3"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps3.sub"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps4"), dafBase.PropertySet)
+
+        self.assertFalse(ps.isArray("ps1"))
+        self.assertTrue(ps.isArray("ps1.pre"))
+        self.assertFalse(ps.isArray("ps1.post"))
+        self.assertFalse(ps.isArray("ps2"))
+        self.assertFalse(ps.isArray("ps2.plus"))
+        self.assertFalse(ps.isArray("ps2.minus"))
+        self.assertFalse(ps.isArray("ps2.foo"))
+        self.assertFalse(ps.isArray("ps3"))
+        self.assertFalse(ps.isArray("ps3.sub"))
+        self.assertFalse(ps.isArray("ps3.subsub"))
+        self.assertFalse(ps.isArray("ps4"))
+        self.assertFalse(ps.isArray("ps4.top"))
+        self.assertTrue(ps.isArray("int"))
+        self.assertFalse(ps.isArray("double"))
+
+        self.assertEqual(ps.valueCount("ps1.pre"), 3)
+        self.assertEqual(ps.valueCount("int"), 2)
+
+        v = ps.getArray("ps1.pre")
+        self.assertEqual(v, [1, 3, 4])
+        v = ps.getArray("int")
+        self.assertEqual(v, [42, 2008])
+
+    def testCombineThrow(self):
+        ps = dafBase.PropertySet()
+        ps.set("int", 42)
+
+        psp = dafBase.PropertySet()
+        psp.set("int", 3.14159)
+
+        with self.assertRaises(TypeError):
+            ps.combine(psp)
+
     def testToDict(self):
         ps = dafBase.PropertySet()
         ps.setBool("bool", True)
@@ -809,66 +868,6 @@ if __name__ == "__main__":
 #     BOOST_CHECK_EQUAL(ps.getAsPropertySetPtr("top"), psp);
 #     BOOST_CHECK_THROW(ps.getAsPropertySetPtr("top.bottom"),
 #                       boost::bad_any_cast);
-# }
-#
-# BOOST_AUTO_TEST_CASE(combine) {
-#     dafBase::PropertySet ps;
-#     ps.set("ps1.pre", 1);
-#     ps.set("ps1.post", 2);
-#     ps.set("int", 42);
-#     ps.set("double", 3.14);
-#     ps.set("ps2.plus", 10.24);
-#     ps.set("ps2.minus", -10.24);
-#     ps.set("ps3.sub.subsub", "foo");
-#
-#     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-#     psp->set("ps1.pre", 3);
-#     psp->add("ps1.pre", 4);
-#     psp->set("int", 2008);
-#     psp->set("ps2.foo", "bar");
-#     psp->set("ps4.top", "bottom");
-#
-#     ps.combine(psp);
-#
-#     BOOST_CHECK(ps.isPropertySetPtr("ps1"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps2"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps3"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps3.sub"));
-#     BOOST_CHECK(ps.isPropertySetPtr("ps4"));
-#     BOOST_CHECK(!ps.isArray("ps1"));
-#     BOOST_CHECK(ps.isArray("ps1.pre"));
-#     BOOST_CHECK(!ps.isArray("ps1.post"));
-#     BOOST_CHECK(!ps.isArray("ps2"));
-#     BOOST_CHECK(!ps.isArray("ps2.plus"));
-#     BOOST_CHECK(!ps.isArray("ps2.minus"));
-#     BOOST_CHECK(!ps.isArray("ps2.foo"));
-#     BOOST_CHECK(!ps.isArray("ps3"));
-#     BOOST_CHECK(!ps.isArray("ps3.sub"));
-#     BOOST_CHECK(!ps.isArray("ps3.subsub"));
-#     BOOST_CHECK(!ps.isArray("ps4"));
-#     BOOST_CHECK(!ps.isArray("ps4.top"));
-#     BOOST_CHECK(ps.isArray("int"));
-#     BOOST_CHECK(!ps.isArray("double"));
-#     BOOST_CHECK_EQUAL(ps.valueCount("ps1.pre"), 3U);
-#     BOOST_CHECK_EQUAL(ps.valueCount("int"), 2U);
-#     std::vector<int> v = ps.getArray<int>("ps1.pre");
-#     BOOST_CHECK_EQUAL(v[0], 1);
-#     BOOST_CHECK_EQUAL(v[1], 3);
-#     BOOST_CHECK_EQUAL(v[2], 4);
-#     v = ps.getArray<int>("int");
-#     BOOST_CHECK_EQUAL(v[0], 42);
-#     BOOST_CHECK_EQUAL(v[1], 2008);
-# }
-#
-# BOOST_AUTO_TEST_CASE(combineThrow) {
-#     dafBase::PropertySet ps;
-#     ps.set("int", 42);
-#
-#     dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
-#     psp->set("int", 3.14159);
-#
-#     BOOST_CHECK_THROW(ps.combine(psp),
-#                       lsst::pex::exceptions::DomainError);
 # }
 #
 # BOOST_AUTO_TEST_CASE(remove) {

--- a/tests/test_dateTime.py
+++ b/tests/test_dateTime.py
@@ -272,15 +272,15 @@ class DateTimeTestCase(unittest.TestCase):
         for scale in self.timeScales:
             self.assertEqual(ts.nsecs(scale), DateTime.invalid_nsecs)
             for system in self.dateSystems:
-                with self.assertRaises(pexExcept.RuntimeError):
+                with self.assertRaises(RuntimeError):
                     ts.get(system, scale)
-            with self.assertRaises(pexExcept.RuntimeError):
+            with self.assertRaises(RuntimeError):
                 ts.gmtime(scale)
-            with self.assertRaises(pexExcept.RuntimeError):
+            with self.assertRaises(RuntimeError):
                 ts.timespec(scale)
-            with self.assertRaises(pexExcept.RuntimeError):
+            with self.assertRaises(RuntimeError):
                 ts.timeval(scale)
-            with self.assertRaises(pexExcept.RuntimeError):
+            with self.assertRaises(RuntimeError):
                 ts.toString(scale)
         self.assertEqual(repr(ts), "DateTime()")
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -143,6 +143,12 @@ class DictTestCase(unittest.TestCase):
         with self.assertRaises(KeyError):
             del container["RANDOM"]
 
+        # Get a comment
+        c = container["int2#COMMENT"]
+        self.assertEqual(c, container.getComment("int2"))
+        container["int2#COMMENT"] = "new comment"
+        self.assertEqual(container["int2#COMMENT"], "new comment")
+
         # Compare dict-like interface to pure dict version
         d = container.toDict()
         self.assertEqual(len(d), len(container))

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -101,6 +101,11 @@ class DictTestCase(unittest.TestCase):
         container["dot.delimited"] = "delimited"
         self.assertIn("dot", container)
 
+        keys = container.keys()
+        self.assertEqual(len(keys), 16)
+        for k in keys:
+            self.assertIn(k, container)
+
         # Assign a PropertySet
         ps2 = lsst.daf.base.PropertySet()
         ps2.setString("newstring", "stringValue")
@@ -131,6 +136,11 @@ class DictTestCase(unittest.TestCase):
         container["new"] = "string"
         container["array"] = [1, 2, 3]
         container["dot.delimited"] = "delimited"
+
+        keys = container.keys()
+        self.assertEqual(len(keys), 16)
+        for k in keys:
+            self.assertIn(k, container)
 
         # Assign a PropertySet
         ps2 = lsst.daf.base.PropertySet()

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,0 +1,101 @@
+# This file is part of daf_base
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org/).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test dict emulation"""
+
+import unittest
+import copy
+
+import lsst.daf.base
+
+
+class DictTestCase(unittest.TestCase):
+
+    def setUp(self):
+
+        pl = lsst.daf.base.PropertyList()
+        pl.setBool("bool", True)
+        pl.setShort("short", 42)
+        pl.setInt("int", 2008)
+        pl.setLongLong("int64_t", 0xfeeddeadbeef)
+        pl.setFloat("float", 3.14159)
+        pl.setDouble("double", 2.718281828459045)
+        pl.set("char*", "foo")
+        pl.setString("string", "bar")
+        pl.set("int2", 2009)
+        pl.set("dt", lsst.daf.base.DateTime("20090402T072639.314159265Z", lsst.daf.base.DateTime.UTC))
+
+        ps = lsst.daf.base.PropertySet()
+        ps.setBool("bool", True)
+        ps.setShort("short", 42)
+        ps.setInt("int", 2008)
+        ps.setLongLong("long", 5)  # Deliberately small
+        ps.setLongLong("int64_t", 0xfeeddeadbeef)
+        ps.setFloat("float", 3.14159)
+        ps.setDouble("double", 2.718281828459045)
+        ps.set("char*", "foo")
+        ps.setString("string", "bar")
+        ps.set("char*", u"foo")
+        ps.setString("string", u"bar")
+        ps.set("int2", 2009)
+        ps.set("dt", lsst.daf.base.DateTime("20090402T072639.314159265Z", lsst.daf.base.DateTime.UTC))
+        ps.set("blank", "")
+
+        ps2 = lsst.daf.base.PropertySet()
+        ps2.setBool("bool2", False)
+        ps2.setShort("short2", 16)
+        ps2.setInt("int2", 2018)
+
+        ps.setPropertySet("ps2", ps2)
+
+        self.ps = ps
+        self.pl = pl
+
+    def testCopyPropertySet(self):
+        shallow = copy.copy(self.ps)
+        self.assertIsInstance(shallow, lsst.daf.base.PropertySet)
+        self.assertIs(shallow["ps2"], self.ps["ps2"])
+        self.assertEqual(shallow, self.ps)
+
+        deep = copy.deepcopy(self.ps)
+        self.assertIsInstance(deep, lsst.daf.base.PropertySet)
+        self.assertEqual(deep, self.ps)
+        del deep["ps2"]
+        self.assertNotIn("ps2", deep)
+        self.assertIn("ps2", self.ps)
+
+    def testDictPropertySet(self):
+        self.assertIn("string", self.ps)
+        self.assertIn("ps2", self.ps)
+        self.assertNotIn("ps2.bool2", self.ps)
+        self.assertIn("bool2", self.ps["ps2"])
+        with self.assertRaises(KeyError):
+            self.ps["RANDOM"]
+        print("NOW LOOPING")
+        for k, v in self.ps.items():
+            print(f"{k!r}: {v!r}")
+
+        d = self.ps.toDict()
+        self.assertEqual(d, self.ps)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -105,6 +105,12 @@ class YAMLTestCase(unittest.TestCase):
         apl2 = yaml.load(yaml.dump(apl))
         self.assertEqual(apl2, apl)
 
+        # Add the PropertyList to the PropertySet to ensure that the
+        # correct type is returned and no loss of comments
+        ps.setPropertySet("newpl", apl)
+        apl3 = yaml.load(yaml.dump(ps))
+        self.assertEqual(apl3, ps)
+
     def testYamlDateTime(self):
         ts = lsst.daf.base.DateTime("2004-03-01T12:39:45.1Z", lsst.daf.base.DateTime.UTC)
         ts2 = yaml.load(yaml.dump(ts))

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -41,12 +41,16 @@ class YAMLTestCase(unittest.TestCase):
         pass
 
     def assertEqualPL(self, pl1, pl2):
+        self.assertEqual(pl1, pl2)
+        self.assertEqual(len(pl1), len(pl2))
         for name in pl1.getOrderedNames():
             self.assertEqual(pl1.getArray(name), pl2.getArray(name))
             self.assertEqual(pl1.getScalar(name), pl2.getScalar(name))
             self.assertEqual(pl1.typeOf(name), pl2.typeOf(name))
 
     def assertEqualPS(self, ps1, ps2):
+        self.assertEqual(ps1, ps2)
+        self.assertEqual(len(ps1), len(ps2))
         self.assertEqual(ps1.nameCount(), ps2.nameCount())
         self.assertEqual(set(ps1.paramNames(False)), set(ps2.paramNames(False)))
         for name in ps1.paramNames(False):
@@ -73,6 +77,10 @@ class YAMLTestCase(unittest.TestCase):
         ps2 = yaml.load(yaml.dump(ps))
         self.assertIsInstance(ps2, lsst.daf.base.PropertySet)
         self.assertEqualPS(ps, ps2)
+        print(ps2)
+        print(f"Length: {len(ps2)}")
+        for n in ps2:
+            print(f"N is {n}")
 
     def testYamlPL(self):
         apl = lsst.daf.base.PropertyList()
@@ -90,6 +98,11 @@ class YAMLTestCase(unittest.TestCase):
         apl2 = yaml.load(yaml.dump(apl))
         self.assertIsInstance(apl2, lsst.daf.base.PropertyList)
         self.assertEqualPL(apl, apl2)
+        print(apl2)
+        print(repr(apl2))
+        print(f"Length: {len(apl2)}")
+        for n, v in apl2.items():
+            print(f"Npl is {n}: {v}")
 
     def testYamlNest(self):
         """Test nested property sets"""

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -40,24 +40,6 @@ class YAMLTestCase(unittest.TestCase):
     def setUp(self):
         pass
 
-    def assertEqualPL(self, pl1, pl2):
-        self.assertEqual(pl1, pl2)
-        self.assertEqual(len(pl1), len(pl2))
-        for name in pl1.getOrderedNames():
-            self.assertEqual(pl1.getArray(name), pl2.getArray(name))
-            self.assertEqual(pl1.getScalar(name), pl2.getScalar(name))
-            self.assertEqual(pl1.typeOf(name), pl2.typeOf(name))
-
-    def assertEqualPS(self, ps1, ps2):
-        self.assertEqual(ps1, ps2)
-        self.assertEqual(len(ps1), len(ps2))
-        self.assertEqual(ps1.nameCount(), ps2.nameCount())
-        self.assertEqual(set(ps1.paramNames(False)), set(ps2.paramNames(False)))
-        for name in ps1.paramNames(False):
-            self.assertEqual(ps1.getArray(name), ps2.getArray(name))
-            self.assertEqual(ps1.getScalar(name), ps2.getScalar(name))
-            self.assertEqual(ps1.typeOf(name), ps2.typeOf(name))
-
     def testYamlPS(self):
         ps = lsst.daf.base.PropertySet()
         ps.setBool("bool", True)
@@ -76,11 +58,7 @@ class YAMLTestCase(unittest.TestCase):
 
         ps2 = yaml.load(yaml.dump(ps))
         self.assertIsInstance(ps2, lsst.daf.base.PropertySet)
-        self.assertEqualPS(ps, ps2)
-        print(ps2)
-        print(f"Length: {len(ps2)}")
-        for n in ps2:
-            print(f"N is {n}")
+        self.assertEqual(ps, ps2)
 
     def testYamlPL(self):
         apl = lsst.daf.base.PropertyList()
@@ -97,12 +75,7 @@ class YAMLTestCase(unittest.TestCase):
 
         apl2 = yaml.load(yaml.dump(apl))
         self.assertIsInstance(apl2, lsst.daf.base.PropertyList)
-        self.assertEqualPL(apl, apl2)
-        print(apl2)
-        print(repr(apl2))
-        print(f"Length: {len(apl2)}")
-        for n, v in apl2.items():
-            print(f"Npl is {n}: {v}")
+        self.assertEqual(apl, apl2)
 
     def testYamlNest(self):
         """Test nested property sets"""
@@ -118,8 +91,8 @@ class YAMLTestCase(unittest.TestCase):
         ps.setPropertySet("ps", ps2)
 
         ps3 = yaml.load(yaml.dump(ps))
-        self.assertEqualPS(ps3, ps)
-        self.assertEqualPS(ps3.getPropertySet("ps"), ps.getPropertySet("ps"))
+        self.assertEqual(ps3, ps)
+        self.assertEqual(ps3.getPropertySet("ps"), ps.getPropertySet("ps"))
 
         # Now for a PropertyList
         apl = lsst.daf.base.PropertyList()
@@ -130,7 +103,7 @@ class YAMLTestCase(unittest.TestCase):
         apl.setPropertySet("ps", ps3)
 
         apl2 = yaml.load(yaml.dump(apl))
-        self.assertEqualPL(apl2, apl)
+        self.assertEqual(apl2, apl)
 
     def testYamlDateTime(self):
         ts = lsst.daf.base.DateTime("2004-03-01T12:39:45.1Z", lsst.daf.base.DateTime.UTC)
@@ -147,9 +120,7 @@ class YAMLTestCase(unittest.TestCase):
             new = yaml.load(fd)
         self.assertIsInstance(new, lsst.daf.base.PropertyList)
         self.assertIsInstance(old, lsst.daf.base.PropertyList)
-
-        # There is no __eq__
-        self.assertEqualPL(old, new)
+        self.assertEqual(old, new)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

* Fixed YAML support to allow YAML/pickle to iterate through hierarchies as needed rather than requiring PropertySet to serialize itself in one go.
* Significant addition of tests for PropertySet and PropertyList by converting the C++ tests that were commented out at the end of the test files.
* Cleanups to remove pex exception usage from Python code.
* Docstring cleanups.
* Addition of many dunder methods implementing dict functionality.

Note that it is not possible for PropertySet to inherit from MutableMapping since pybind11 does not allow a C++ class to inherit from a Python class.