### PR TITLE
DM-9938: Make some afw types hashable

### DIFF
--- a/include/lsst/daf/base/DateTime.h
+++ b/include/lsst/daf/base/DateTime.h
@@ -203,6 +203,9 @@ public:
 
     bool operator==(DateTime const& rhs) const;
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /** Return current time as a DateTime
      *
      * Assumes the system clock keeps UTC, as almost all computers do.
@@ -300,5 +303,14 @@ private:
 }  // namespace base
 }  // namespace daf
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::daf::base::DateTime> {
+    using argument_type = lsst::daf::base::DateTime;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/src/DateTime.cc
+++ b/src/DateTime.cc
@@ -512,6 +512,8 @@ std::string DateTime::toString(Timescale scale) const {
 
 bool DateTime::operator==(DateTime const& rhs) const { return _nsecs == rhs._nsecs; }
 
+std::size_t DateTime::hash_value() const noexcept { return std::hash<long long>()(_nsecs); }
+
 DateTime DateTime::now(void) {
     struct timeval tv;
     int ret = gettimeofday(&tv, 0);

--- a/tests/test_dateTime_1.cc
+++ b/tests/test_dateTime_1.cc
@@ -29,6 +29,7 @@
 #include "boost/test/unit_test.hpp"
 #pragma clang diagnostic pop
 
+#include "lsst/utils/tests.h"
 #include "lsst/pex/exceptions.h"
 
 namespace test = boost::test_tools;
@@ -87,6 +88,13 @@ BOOST_AUTO_TEST_CASE(Throw) {
         BOOST_CHECK_THROW(DateTime("2039-01-01T12:34:56Z", DateTime::UTC),
                           lsst::pex::exceptions::DomainError);
     }
+}
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    lsst::utils::assertValidHash<DateTime>();
+
+    DateTime date1("20090402T072639.314159265Z", DateTime::UTC);
+    lsst::utils::assertHashesEqual(date1, DateTime(date1.nsecs()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR makes the minimum changes to `daf_base` needed to make `afw::image::VisitInfo` hashable.