### PR TITLE
DM-19873: Resurrect get() and add __getitem__ calling it

### DIFF
--- a/python/lsst/daf/base/citizen/citizenContinued.py
+++ b/python/lsst/daf/base/citizen/citizenContinued.py
@@ -30,15 +30,16 @@ from .citizen import Citizen
 
 
 def setCallbacks(new=None, delete=None, both=False):
-    """Set the callback IDs for the Citizen; if both is true, set both new and delete to the same value
+    """Set the callback IDs for the Citizen; if both is true, set both new and
+    delete to the same value.
 
     You probably want to chant the following to gdb:
-       break defaultNewCallback
-       break defaultDeleteCallback
+    * break defaultNewCallback
+    * break defaultDeleteCallback
 
-    You might want to put this in your .gdbinit file.
+    You might want to put this in your ``.gdbinit`` file.
 
-    You can retrieve a citizen's signature from python with obj.repr()
+    You can retrieve a citizen's signature from python with ``obj.repr()``.
     """
 
     if both:
@@ -60,8 +61,10 @@ def mortal(memId0=0, nleakPrintMax=20, first=True, showTypes=None):
 
     @param memId0 Only consider blocks allocated after this memId
     @param nleakPrintMax Maximum number of leaks to print; <= 0 means unlimited
-    @param first Print the first nleakPrintMax blocks; if False print the last blocks.
-    @param showTypes Only print objects matching this regex (if starts with !, print objects that don't match)
+    @param first Print the first nleakPrintMax blocks; if False print the last
+           blocks.
+    @param showTypes Only print objects matching this regex (if starts with !,
+           print objects that don't match)
 
     If you want finer control than nleakPrintMax/first provide, use
     Citizen.census() to get the entire list

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -237,8 +237,8 @@ def _guessIntegerType(container, name, value):
         try:
             containerType = _propertyContainerElementTypeName(container, name)
         except LookupError:
-            # nothing in the container so choose based on size. Safe option is to
-            # always use LongLong
+            # nothing in the container so choose based on size. Safe option is
+            # to always use LongLong
             if value <= maxInt and value >= minInt:
                 useType = "Int"
             else:
@@ -247,8 +247,8 @@ def _guessIntegerType(container, name, value):
             if containerType == "Int":
                 # Always use an Int even if we know it won't fit. The later
                 # code will trigger OverflowError if appropriate. Setting the
-                # type to LongLong here will trigger a TypeError instead so it's
-                # best to trigger a predictable OverflowError.
+                # type to LongLong here will trigger a TypeError instead so
+                # it's best to trigger a predictable OverflowError.
                 useType = "Int"
             elif containerType == "LongLong":
                 useType = "LongLong"

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -26,7 +26,6 @@ __all__ = ["getPropertySetState", "getPropertyListState", "setPropertySetState",
 
 import enum
 import numbers
-import warnings
 from collections.abc import Mapping, KeysView
 
 # Ensure that C++ exceptions are properly translated to Python
@@ -340,27 +339,30 @@ class PropertySet:
                  None: "Undef",
                  }
 
-    def get(self, name):
-        """Return an item as a scalar or array
+    def get(self, name, default=None):
+        """Return an item as a scalar, else default.
 
-        Return an array if the item is of numeric or string type and has
-        more than one value, otherwise return a scalar.
-
-        .. deprecated:: 20180-06
-                  `get` is superseded by `getArray` or `getScalar`
+        Identical to `getScalar` except that a default value is returned
+        if the requested key is not present.
 
         Parameters
         ----------
         name : ``str``
             Name of item
+        default : `object`, optional
+            Default value to use if the named item is not present.
 
-        Raises
-        ------
-        KeyError
-            If the item does not exist.
+        Returns
+        -------
+        value : any type supported by container
+            Single value of any type supported by the container, else the
+            default value if the requested item is not present in the
+            container.
         """
-        warnings.warn("Use getArray or getScalar instead", DeprecationWarning, stacklevel=2)
-        return _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
+        try:
+            return _propertyContainerGet(self, name, returnStyle=ReturnStyle.SCALAR)
+        except KeyError:
+            return default
 
     def getArray(self, name):
         """Return an item as an array if the item is numeric or string
@@ -372,6 +374,11 @@ class PropertySet:
         ----------
         name : `str`
             Name of item
+
+        Returns
+        -------
+        values : `list` of any type supported by container
+            List of values of any type supported by the container.
 
         Raises
         ------
@@ -389,6 +396,11 @@ class PropertySet:
         ----------
         name : `str`
             Name of item
+
+        Returns
+        -------
+        value : any type supported by container
+            Single value of any type supported by the container.
 
         Raises
         ------
@@ -501,6 +513,9 @@ class PropertySet:
             value = ps
         self.set(name, value)
 
+    def __getitem__(self, name):
+        return self.getScalar(name)
+
     def __delitem__(self, name):
         if name in self:
             self.remove(name)
@@ -544,27 +559,30 @@ class PropertyList:
 
     COMMENTSUFFIX = "#COMMENT"
 
-    def get(self, name):
-        """Return an item as a scalar or array
+    def get(self, name, default=None):
+        """Return an item as a scalar, else default.
 
-        Return an array if the item has more than one value,
-        otherwise return a scalar.
-
-        .. deprecated:: 20180-06
-                  `get` is superseded by `getArray` or `getScalar`
+        Identical to `getScalar` except that a default value is returned
+        if the requested key is not present.
 
         Parameters
         ----------
-        name : `str`
+        name : ``str``
             Name of item
+        default : `object`, optional
+            Default value to use if the named item is not present.
 
-        Raises
-        ------
-        KeyError
-            If the item does not exist.
+        Returns
+        -------
+        value : any type supported by container
+            Single value of any type supported by the container, else the
+            default value if the requested item is not present in the
+            container.
         """
-        warnings.warn("Use getArray or getScalar instead", DeprecationWarning, stacklevel=2)
-        return _propertyContainerGet(self, name, returnStyle=ReturnStyle.AUTO)
+        try:
+            return _propertyContainerGet(self, name, returnStyle=ReturnStyle.SCALAR)
+        except KeyError:
+            return default
 
     def getArray(self, name):
         """Return an item as an array

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -453,6 +453,27 @@ class PropertySet:
         """
         return _propertyContainerAdd(self, name, value, self._typeMenu)
 
+    def update(self, addition):
+        """Update the current container with the supplied additions.
+
+        Parameters
+        ----------
+        addition : `collections.abc.Mapping` or `PropertySet`
+            The content to merge into the current container.
+
+        Notes
+        -----
+        If the supplied parameter is a `PropertySet` then the
+        `PropertySet.combine` method will be used.  If the supplied parameter
+        is a `collections.abc.Mapping` each item will be copied out of the
+        mapping and value assigned.
+        """
+        if isinstance(addition, PropertySet):
+            self.combine(addition)
+        else:
+            for k, v in addition.items():
+                self[k] = v
+
     def toDict(self):
         """Returns a (possibly nested) dictionary with all properties.
 

--- a/python/lsst/daf/base/yaml.py
+++ b/python/lsst/daf/base/yaml.py
@@ -101,7 +101,8 @@ def dt_constructor(loader, node):
 
 
 def pl_constructor(loader, node):
-    """Construct an lsst.daf.base.PropertyList from a YAML pickle-like structure."""
+    """Construct an lsst.daf.base.PropertyList from a YAML pickle-like
+    structure."""
     pl = PropertyList()
     yield pl
     state = loader.construct_sequence(node, deep=True)
@@ -109,7 +110,8 @@ def pl_constructor(loader, node):
 
 
 def ps_constructor(loader, node):
-    """Construct an lsst.daf.base.PropertyList from a YAML pickle-like structure."""
+    """Construct an lsst.daf.base.PropertyList from a YAML pickle-like
+    structure."""
     ps = PropertySet()
     yield ps
     state = loader.construct_sequence(node, deep=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 110
+max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816
 exclude = __init__.py
 

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -29,7 +29,8 @@ import lsst.daf.base as dafBase
 
 
 class FloatSubClass(float):
-    """Intended to be something like numpy.float64, without introducing a dependency on numpy"""
+    """Intended to be something like numpy.float64, without introducing a
+    dependency on numpy"""
     pass
 
 

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -81,18 +81,18 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(apl.getString("string"), "bar")
         self.assertEqual(apl.typeOf("int2"), dafBase.PropertyList.TYPE_Int)
         self.assertEqual(apl.getInt("int2"), 2009)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("int2"), 2009)
+        self.assertEqual(apl.get("int2"), 2009)
         self.assertEqual(apl.getArray("int2"), [2009])
         self.assertEqual(apl.getScalar("int2"), 2009)
         self.assertEqual(apl.typeOf("dt"), dafBase.PropertyList.TYPE_DateTime)
         self.assertEqual(apl.getDateTime("dt").nsecs(), 1238657233314159265)
         self.assertEqual(apl.getDouble("subclass"), 1.23456789)
+        self.assertEqual(apl["int2"], 2009)
 
         self.assertIsNone(apl.getScalar("undef"))
         self.assertEqual(apl.typeOf("undef"), dafBase.PropertyList.TYPE_Undef)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIsNone(apl.get("undef"))
+        self.assertIsNone(apl.get("undef"))
+        self.assertIsNone(apl["undef"])
         self.checkPickle(apl)
 
         # Now replace the undef value with a defined value
@@ -107,6 +107,11 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(apl.getInt("int"), 42)
         self.assertEqual(apl.getInt("int", 2008), 42)
         self.assertEqual(apl.getInt("foo", 2008), 2008)
+        self.assertEqual(apl.get("int"), 42)
+        self.assertEqual(apl.get("int", 2008), 42)
+        self.assertEqual(apl.get("foo", 2008), 2008)
+        self.assertEqual(apl.get("foo2", default="missing"), "missing")
+        self.assertIsNone(apl.get("foo"))
 
     def testExists(self):
         apl = dafBase.PropertyList()
@@ -124,18 +129,18 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(v, w)
         self.assertEqual(apl.getInt("ints2"), 8)
         self.assertEqual(apl.getArrayInt("ints2"), [10, 9, 8])
-        with self.assertWarns(DeprecationWarning):
-            w = apl.get("ints")
-        self.assertEqual(len(w), 3)
-        self.assertEqual(v, w)
+        w = apl.get("ints")
+        self.assertIsInstance(w, int)
+        self.assertEqual(v[-1], w)
+        self.assertEqual(apl["ints"], v[-1])
         self.assertEqual(apl.getArray("ints"), v)
         self.assertEqual(apl.getScalar("ints"), v[-1])
         apl.setInt("int", 999)
-        with self.assertWarns(DeprecationWarning):
-            x = apl.get("int")
+        x = apl.get("int")
         self.assertEqual(x, 999)
         self.assertEqual(apl.getArray("int"), [999])
         self.assertEqual(apl.getScalar("int"), 999)
+        self.assertEqual(apl["int"], 999)
 
         self.checkPickle(apl)
 
@@ -170,8 +175,7 @@ class PropertyListTestCase(unittest.TestCase):
         self.assertEqual(w[3], -999)
         self.assertEqual(w[4], 13)
         self.assertEqual(apl.getString("other"), "foo")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("subclass"), 1.23456789)
+        self.assertEqual(apl.get("subclass"), 1.23456789)
         self.assertEqual(apl.getArray("subclass"), [1.23456789])
         self.assertEqual(apl.getScalar("subclass"), 1.23456789)
 
@@ -191,9 +195,8 @@ class PropertyListTestCase(unittest.TestCase):
         apl.setDouble("double", 2.718281828459045)
         apl.setString("string", "bar")
 
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(KeyError):
-                apl.get("foo")
+        with self.assertRaises(KeyError):
+            apl["foo"]
         with self.assertRaises(TypeError):
             apl.getBool("short")
         with self.assertRaises(TypeError):
@@ -220,22 +223,19 @@ class PropertyListTestCase(unittest.TestCase):
         apl.add("subclass", subclass)
         self.assertEqual(apl.getArrayInt("ints"),
                          [42, 2008, 1, -42, -2008, -1])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("subclass"), subclass)
+        self.assertEqual(apl.get("subclass"), subclass[-1])
         self.assertEqual(apl.getArray("subclass"), subclass)
         self.assertEqual(apl.getScalar("subclass"), subclass[-1])
 
     def testComment(self):
         apl = dafBase.PropertyList()
         apl.set("NAXIS", 2, "two-dimensional")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("NAXIS"), 2)
+        self.assertEqual(apl.get("NAXIS"), 2)
         self.assertEqual(apl.getArray("NAXIS"), [2])
         self.assertEqual(apl.getScalar("NAXIS"), 2)
         self.assertEqual(apl.getComment("NAXIS"), "two-dimensional")
         apl.set("NAXIS", 3, "three-dimensional")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("NAXIS"), 3)
+        self.assertEqual(apl.get("NAXIS"), 3)
         self.assertEqual(apl.getArray("NAXIS"), [3])
         self.assertEqual(apl.getScalar("NAXIS"), 3)
         self.assertEqual(apl.getComment("NAXIS"), "three-dimensional")
@@ -321,16 +321,13 @@ class PropertyListTestCase(unittest.TestCase):
         apl.set("CURRENT", 49.5)
         apl.set("CURRENT.foo", -32)
         apl.set("CURRENT.bar", 2)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("CURRENT"), 49.5)
+        self.assertEqual(apl.get("CURRENT"), 49.5)
         self.assertEqual(apl.getArray("CURRENT"), [49.5])
         self.assertEqual(apl.getScalar("CURRENT"), 49.5)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("CURRENT.foo"), -32)
+        self.assertEqual(apl.get("CURRENT.foo"), -32)
         self.assertEqual(apl.getArray("CURRENT.foo"), [-32])
         self.assertEqual(apl.getScalar("CURRENT.foo"), -32)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("CURRENT.bar"), 2)
+        self.assertEqual(apl.get("CURRENT.bar"), 2)
         self.assertEqual(apl.getArray("CURRENT.bar"), [2])
         self.assertEqual(apl.getScalar("CURRENT.bar"), 2)
 
@@ -338,17 +335,14 @@ class PropertyListTestCase(unittest.TestCase):
         aps.set("bottom", "x")
         aps.set("sibling", 42)
         apl.set("top", aps)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("top.bottom"), "x")
+        self.assertEqual(apl.get("top.bottom"), "x")
         self.assertEqual(apl.getArray("top.bottom"), ["x"])
         self.assertEqual(apl.getScalar("top.bottom"), "x")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(apl.get("top.sibling"), 42)
+        self.assertEqual(apl.get("top.sibling"), 42)
         self.assertEqual(apl.getArray("top.sibling"), [42])
         self.assertEqual(apl.getScalar("top.sibling"), 42)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(KeyError):
-                apl.get("top")
+        with self.assertRaises(KeyError):
+            apl["top"]
         self.assertEqual(apl.toString(),
                          'CURRENT = 49.500000000000\nCURRENT.foo = -32\nCURRENT.bar = 2\n'
                          'top.sibling = 42\ntop.bottom = "x"\n')
@@ -372,8 +366,7 @@ class PropertyListTestCase(unittest.TestCase):
         pl1 = dafBase.PropertyList()
         pl1.set("a.b", 1)
         pl2 = pl1.deepCopy()  # should not segfault
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(pl1.get("a.b"), pl2.get("a.b"))
+        self.assertEqual(pl1.get("a.b"), pl2.get("a.b"))
         self.assertEqual(pl1.getArray("a.b"), pl2.getArray("a.b"))
         self.assertEqual(pl1.getScalar("a.b"), pl2.getScalar("a.b"))
         self.checkPickle(pl1)
@@ -384,8 +377,7 @@ class PropertyListTestCase(unittest.TestCase):
         value1 = [1.5, 3.2]
         source.set("srcItem1", value1)
         dest.copy("destItem1", source, "srcItem1")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem1"), value1)
+        self.assertEqual(dest.get("destItem1"), value1[-1])
         self.assertEqual(dest.getArray("destItem1"), value1)
         self.assertEqual(dest.getScalar("destItem1"), value1[-1])
 
@@ -394,15 +386,13 @@ class PropertyListTestCase(unittest.TestCase):
         value2 = [5, -4, 3]
         source.set("srcItem2", value2)
         dest.copy("destItem2", source, "srcItem2")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem2"), value2)
+        self.assertEqual(dest.get("destItem2"), value2[-1])
         self.assertEqual(dest.getArray("destItem2"), value2)
         self.assertEqual(dest.getScalar("destItem2"), value2[-1])
 
         # asScalar copies only the last value
         dest.copy("destItem2Scalar", source, "srcItem2", asScalar=True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem2Scalar"), value2[-1])
+        self.assertEqual(dest.get("destItem2Scalar"), value2[-1])
         self.assertEqual(dest.getArray("destItem2Scalar"), [value2[-1]])
         self.assertEqual(dest.getScalar("destItem2Scalar"), value2[-1])
 

--- a/tests/test_PropertyList.py
+++ b/tests/test_PropertyList.py
@@ -610,6 +610,53 @@ class PropertyListTestCase(unittest.TestCase):
         v = apl.getArray("int")
         self.assertEqual(v, [42, 2008])
 
+    def testUpdate(self):
+        apl = dafBase.PropertyList()
+        apl.set("apl1.pre", 1)
+        apl.set("apl1.post", 2)
+        apl.set("int", 42)
+        apl.set("double", 3.14)
+        apl.set("apl2.plus", 10.24)
+        apl.set("apl2.minus", -10.24)
+        apl.set("apl3.sub.subsub", "foo")
+
+        aplp = dafBase.PropertyList()
+        aplp.set("apl1.pre", 3)
+        aplp.add("apl1.pre", 4)
+        aplp.set("int", 2008)
+        aplp.set("apl2.foo", "bar")
+        aplp.set("apl4.top", "bottom")
+
+        apl.update(aplp)
+
+        self.assertFalse(apl.isArray("apl1"))
+        self.assertTrue(apl.isArray("apl1.pre"))
+        self.assertFalse(apl.isArray("apl1.post"))
+        self.assertFalse(apl.isArray("apl2"))
+        self.assertFalse(apl.isArray("apl2.plus"))
+        self.assertFalse(apl.isArray("apl2.minus"))
+        self.assertFalse(apl.isArray("apl2.foo"))
+        self.assertFalse(apl.isArray("apl3"))
+        self.assertFalse(apl.isArray("apl3.sub"))
+        self.assertFalse(apl.isArray("apl3.subsub"))
+        self.assertFalse(apl.isArray("apl4"))
+        self.assertFalse(apl.isArray("apl4.top"))
+        self.assertTrue(apl.isArray("int"))
+        self.assertFalse(apl.isArray("double"))
+        self.assertEqual(apl.valueCount("apl1.pre"), 3)
+        self.assertEqual(apl.valueCount("int"), 2)
+        v = apl.getArray("apl1.pre")
+        self.assertEqual(v, [1, 3, 4])
+        v = apl.getArray("int")
+        self.assertEqual(v, [42, 2008])
+
+        apld = {"int": 100, "str": "String", "apl1.foo": 10.5}
+        apl.update(apld)
+        self.assertEqual(apl["int"], apld["int"])
+        self.assertEqual(apl["str"], apld["str"])
+        self.assertEqual(apl["apl1.foo"], apld["apl1.foo"])
+        self.assertEqual(apl["double"], 3.14)
+
     def testCombineThrow(self):
         apl = dafBase.PropertyList()
         apl.set("int", 42)
@@ -619,6 +666,10 @@ class PropertyListTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             apl.combine(aplp)
+
+        psd = {"bool": True}
+        with self.assertRaises(TypeError):
+            apl.combine(psd)
 
     def testremove(self):
         apl = dafBase.PropertyList()

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -78,8 +78,8 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.getString("string"), "bar")
         self.assertEqual(ps.typeOf("int2"), dafBase.PropertySet.TYPE_Int)
         self.assertEqual(ps.getInt("int2"), 2009)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("int2"), 2009)
+        self.assertEqual(ps.get("int2"), 2009)
+        self.assertEqual(ps["int2"], 2009)
         self.assertEqual(ps.getArray("int2"), [2009])
         self.assertEqual(ps.getScalar("int2"), 2009)
         self.assertEqual(ps.typeOf("dt"), dafBase.PropertySet.TYPE_DateTime)
@@ -88,8 +88,7 @@ class PropertySetTestCase(unittest.TestCase):
 
         self.assertIsNone(ps.getScalar("undef"))
         self.assertEqual(ps.typeOf("undef"), dafBase.PropertyList.TYPE_Undef)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIsNone(ps.get("undef"))
+        self.assertIsNone(ps.get("undef"))
 
         self.checkPickle(ps)
 
@@ -127,6 +126,11 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.getInt("int"), 42)
         self.assertEqual(ps.getInt("int", 2008), 42)
         self.assertEqual(ps.getInt("foo", 2008), 2008)
+        self.assertEqual(ps.get("int"), 42)
+        self.assertEqual(ps.get("int", 2008), 42)
+        self.assertEqual(ps.get("foo", 2008), 2008)
+        self.assertEqual(ps.get("foo2", default="missing"), "missing")
+        self.assertIsNone(ps.get("foo"))
         self.checkPickle(ps)
 
     def testExists(self):
@@ -148,12 +152,13 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.getArrayInt("ints2"), [10, 9, 8])
         self.assertEqual(ps.getArray("ints"), v)
         self.assertEqual(ps.getScalar("ints"), v[-1])
+        self.assertEqual(ps["ints"], v[-1])
         ps.setInt("int", 999)
-        with self.assertWarns(DeprecationWarning):
-            x = ps.get("int")
+        x = ps.get("int")
         self.assertEqual(x, 999)
         self.assertEqual(ps.getArray("int"), [999])
         self.assertEqual(ps.getScalar("int"), 999)
+        self.assertEqual(ps["int"], 999)
         self.checkPickle(ps)
 
     def testGetVector2(self):
@@ -197,20 +202,16 @@ class PropertySetTestCase(unittest.TestCase):
         ps.set("ints", intArr)
         ps.set("floats", floatArr)
         ps.set("strs", strArr)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("bools"), boolArr)
+        self.assertEqual(ps.get("bools"), boolArr[-1])
         self.assertEqual(ps.getArray("bools"), boolArr)
         self.assertEqual(ps.getScalar("bools"), boolArr[-1])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("ints"), intArr)
+        self.assertEqual(ps.get("ints"), intArr[-1])
         self.assertEqual(ps.getArray("ints"), intArr)
         self.assertEqual(ps.getScalar("ints"), intArr[-1])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("floats"), floatArr)
+        self.assertEqual(ps.get("floats"), floatArr[-1])
         self.assertEqual(ps.getArray("floats"), floatArr)
         self.assertEqual(ps.getScalar("floats"), floatArr[-1])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("strs"), strArr)
+        self.assertEqual(ps.get("strs"), strArr[-1])
         self.assertEqual(ps.getArray("strs"), strArr)
         self.assertEqual(ps.getScalar("strs"), strArr[-1])
 
@@ -218,20 +219,16 @@ class PropertySetTestCase(unittest.TestCase):
         ps.add("ints", list(reversed(intArr)))
         ps.add("floats", list(reversed(floatArr)))
         ps.add("strs", list(reversed(strArr)))
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("bools"), boolArr + list(reversed(boolArr)))
+        self.assertEqual(ps.get("bools"), boolArr[0])
         self.assertEqual(ps.getArray("bools"), boolArr + list(reversed(boolArr)))
         self.assertEqual(ps.getScalar("bools"), boolArr[0])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("ints"), intArr + list(reversed(intArr)))
+        self.assertEqual(ps.get("ints"), intArr[0])
         self.assertEqual(ps.getArray("ints"), intArr + list(reversed(intArr)))
         self.assertEqual(ps.getScalar("ints"), intArr[0])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("floats"), floatArr + list(reversed(floatArr)))
+        self.assertEqual(ps.get("floats"), floatArr[0])
         self.assertEqual(ps.getArray("floats"), floatArr + list(reversed(floatArr)))
         self.assertEqual(ps.getScalar("floats"), floatArr[0])
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("strs"), strArr + list(reversed(strArr)))
+        self.assertEqual(ps.get("strs"), strArr[0])
         self.assertEqual(ps.getArray("strs"), strArr + list(reversed(strArr)))
         self.assertEqual(ps.getScalar("strs"), strArr[0])
         self.checkPickle(ps)
@@ -248,9 +245,10 @@ class PropertySetTestCase(unittest.TestCase):
         ps.setBool("bool", True)
         ps.setShort("short", 42)
         ps.setInt("int", 2008)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(KeyError):
-                ps.get("foo")
+        with self.assertRaises(KeyError):
+            ps["foo"]
+        # This will not throw
+        self.assertIsNone(ps.get("foo"))
         self.checkPickle(ps)
 
     def testSubPS(self):
@@ -260,24 +258,20 @@ class PropertySetTestCase(unittest.TestCase):
         ps.setPropertySet("b", ps1)
         self.assertEqual(ps.getArray("b"), ps1)
         self.assertEqual(ps.getScalar("b"), ps1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b.a"), 1)
+        self.assertEqual(ps.get("b.a"), 1)
         self.assertEqual(ps.getArray("b.a"), [1])
         self.assertEqual(ps.getScalar("b.a"), 1)
         ps.set("c", ps1)
         self.assertEqual(ps.getArray("c"), ps1)
         self.assertEqual(ps.getScalar("c"), ps1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("c.a"), 1)
+        self.assertEqual(ps.get("c.a"), 1)
         self.assertEqual(ps.getArray("c.a"), [1])
         self.assertEqual(ps.getScalar("c.a"), 1)
         ps.set("c.a", 2)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b.a"), 2)
+        self.assertEqual(ps.get("b.a"), 2)
         self.assertEqual(ps.getArray("b.a"), [2])
         self.assertEqual(ps.getScalar("b.a"), 2)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b").get("a"), 2)
+        self.assertEqual(ps.get("b").get("a"), 2)
         self.checkPickle(ps)
 
     def testCopy(self):
@@ -286,8 +280,7 @@ class PropertySetTestCase(unittest.TestCase):
         value1 = [1.5, 3.2]
         source.set("srcItem1", value1)
         dest.copy("destItem1", source, "srcItem1")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem1"), value1)
+        self.assertEqual(dest.get("destItem1"), value1[-1])
         self.assertEqual(dest.getArray("destItem1"), value1)
         self.assertEqual(dest.getScalar("destItem1"), value1[-1])
 
@@ -296,15 +289,13 @@ class PropertySetTestCase(unittest.TestCase):
         value2 = [5, -4, 3]
         source.set("srcItem2", value2)
         dest.copy("destItem2", source, "srcItem2")
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem2"), value2)
+        self.assertEqual(dest.get("destItem2"), value2[-1])
         self.assertEqual(dest.getArray("destItem2"), value2)
         self.assertEqual(dest.getScalar("destItem2"), value2[-1])
 
         # asScalar copies only the last value
         dest.copy("destItem2Scalar", source, "srcItem2", asScalar=True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(dest.get("destItem2Scalar"), value2[-1])
+        self.assertEqual(dest.get("destItem2Scalar"), value2[-1])
         self.assertEqual(dest.getArray("destItem2Scalar"), [value2[-1]])
         self.assertEqual(dest.getScalar("destItem2Scalar"), value2[-1])
 
@@ -332,8 +323,7 @@ class FlatTestCase(unittest.TestCase):
 
         self.assertEqual(ps.typeOf("bool"), dafBase.PropertySet.TYPE_Bool)
         self.assertIs(ps.getBool("bool"), True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIs(ps.get("bool"), True)
+        self.assertIs(ps.get("bool"), True)
         self.assertEqual(ps.getArray("bool"), [True])
         self.assertIs(ps.getScalar("bool"), True)
         self.assertEqual(ps.typeOf("short"), dafBase.PropertySet.TYPE_Short)
@@ -353,15 +343,13 @@ class FlatTestCase(unittest.TestCase):
         self.assertEqual(ps.getString("string"), "bar")
         self.assertEqual(ps.typeOf("int2"), dafBase.PropertySet.TYPE_Int)
         self.assertEqual(ps.getInt("int2"), 2009)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("int2"), 2009)
+        self.assertEqual(ps.get("int2"), 2009)
         self.assertEqual(ps.getArray("int2"), [2009])
         self.assertEqual(ps.getScalar("int2"), 2009)
         self.assertEqual(ps.typeOf("dt"), dafBase.PropertySet.TYPE_DateTime)
         self.assertEqual(ps.getDateTime("dt").nsecs(), 1238657233314159265)
         self.assertEqual(ps.typeOf("autobool"), dafBase.PropertySet.TYPE_Bool)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIs(ps.get("autobool"), True)
+        self.assertIs(ps.get("autobool"), True)
         self.assertEqual(ps.getArray("autobool"), [True])
         self.assertIs(ps.getScalar("autobool"), True)
 
@@ -391,8 +379,7 @@ class FlatTestCase(unittest.TestCase):
         self.assertEqual(ps.getArray("ints"), v)
         self.assertEqual(ps.getScalar("ints"), v[-1])
         ps.setInt("int", 999)
-        with self.assertWarns(DeprecationWarning):
-            x = ps.get("int")
+        x = ps.get("int")
         self.assertEqual(x, 999)
         self.assertEqual(ps.getArray("int"), [999])
         self.assertEqual(ps.getScalar("int"), 999)
@@ -434,9 +421,9 @@ class FlatTestCase(unittest.TestCase):
         ps.setBool("bool", True)
         ps.setShort("short", 42)
         ps.setInt("int", 2008)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(KeyError):
-                ps.get("foo")
+        with self.assertRaises(KeyError):
+            ps["foo"]
+        self.assertIsNone(ps.get("foo"))
 
     def testSubPS(self):
         ps = dafBase.PropertySet(flat=True)
@@ -446,21 +433,18 @@ class FlatTestCase(unittest.TestCase):
         ps1.set("foo", "bar")
         ps.setPropertySet("b", ps1)
         self.assertEqual(ps.exists("b.a"), True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b.a"), [1, 2])
+        self.assertEqual(ps.get("b.a"), 2)
         self.assertEqual(ps.getArray("b.a"), [1, 2])
         self.assertEqual(ps.getScalar("b.a"), 2)
         self.assertEqual(ps.exists("b"), False)
         self.assertEqual(ps.exists("b.foo"), True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b.foo"), "bar")
+        self.assertEqual(ps.get("b.foo"), "bar")
         self.assertEqual(ps.getArray("b.foo"), ["bar"])
         self.assertEqual(ps.getScalar("b.foo"), "bar")
 
         ps.set("b.c", 20)
         self.assertEqual(ps.exists("b.c"), True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(ps.get("b.c"), 20)
+        self.assertEqual(ps.get("b.c"), 20)
         self.assertEqual(ps.getArray("b.c"), [20])
         self.assertEqual(ps.getScalar("b.c"), 20)
         self.assertEqual(ps.exists("b"), False)

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -99,7 +99,8 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.typeOf("undef"), dafBase.PropertyList.TYPE_String)
 
     def testNumPyScalars(self):
-        """Test that we can also pass NumPy array scalars to PropertySet setters.
+        """Test that we can also pass NumPy array scalars to PropertySet
+        setters.
         """
         ps = dafBase.PropertySet()
         ps.setShort("short", np.int16(42))

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -498,6 +498,62 @@ class FlatTestCase(unittest.TestCase):
         v = ps.getArray("int")
         self.assertEqual(v, [42, 2008])
 
+    def testUpdate(self):
+        ps = dafBase.PropertySet()
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.pre", 1)
+        ps.set("ps1.post", 2)
+        ps.set("int", 42)
+        ps.set("double", 3.14)
+        ps.set("ps2.plus", 10.24)
+        ps.set("ps2.minus", -10.24)
+        ps.set("ps3.sub.subsub", "foo")
+
+        psp = dafBase.PropertySet()
+        psp.set("ps1.pre", 3)
+        psp.add("ps1.pre", 4)
+        psp.set("int", 2008)
+        psp.set("ps2.foo", "bar")
+        psp.set("ps4.top", "bottom")
+
+        ps.update(psp)
+
+        self.assertIsInstance(ps.getScalar("ps1"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps2"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps3"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps3.sub"), dafBase.PropertySet)
+        self.assertIsInstance(ps.getScalar("ps4"), dafBase.PropertySet)
+
+        self.assertFalse(ps.isArray("ps1"))
+        self.assertTrue(ps.isArray("ps1.pre"))
+        self.assertFalse(ps.isArray("ps1.post"))
+        self.assertFalse(ps.isArray("ps2"))
+        self.assertFalse(ps.isArray("ps2.plus"))
+        self.assertFalse(ps.isArray("ps2.minus"))
+        self.assertFalse(ps.isArray("ps2.foo"))
+        self.assertFalse(ps.isArray("ps3"))
+        self.assertFalse(ps.isArray("ps3.sub"))
+        self.assertFalse(ps.isArray("ps3.subsub"))
+        self.assertFalse(ps.isArray("ps4"))
+        self.assertFalse(ps.isArray("ps4.top"))
+        self.assertTrue(ps.isArray("int"))
+        self.assertFalse(ps.isArray("double"))
+
+        self.assertEqual(ps.valueCount("ps1.pre"), 3)
+        self.assertEqual(ps.valueCount("int"), 2)
+
+        v = ps.getArray("ps1.pre")
+        self.assertEqual(v, [1, 3, 4])
+        v = ps.getArray("int")
+        self.assertEqual(v, [42, 2008])
+
+        psd = {"int": 100, "str": "String", "apl1.foo": 10.5}
+        ps.update(psd)
+        self.assertEqual(ps["int"], psd["int"])
+        self.assertEqual(ps["str"], psd["str"])
+        self.assertEqual(ps["apl1.foo"], psd["apl1.foo"])
+        self.assertEqual(ps["double"], 3.14)
+
     def testCombineThrow(self):
         ps = dafBase.PropertySet()
         ps.set("int", 42)
@@ -507,6 +563,10 @@ class FlatTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             ps.combine(psp)
+
+        psd = {"bool": True}
+        with self.assertRaises(TypeError):
+            ps.combine(psd)
 
     def testToDict(self):
         ps = dafBase.PropertySet()

--- a/tests/test_dateTime.py
+++ b/tests/test_dateTime.py
@@ -177,7 +177,8 @@ class DateTimeTestCase(unittest.TestCase):
             with self.assertRaises(pexExcept.DomainError):
                 DateTime("09-04-01T23:36:05", DateTime.UTC)  # 2 digit year
 
-        # earliest allowed UTC date is the earliest date in the leap second table
+        # earliest allowed UTC date is the earliest date in the leap second
+        # table
         try:
             minLeapSecUTC = "1961-01-01T00:00:00Z"
             dt = DateTime(minLeapSecUTC, DateTime.UTC)
@@ -197,7 +198,8 @@ class DateTimeTestCase(unittest.TestCase):
             except Exception:
                 self.fail("{} system={} failed, but should be OK".format(earliestDate, timeSys))
 
-        # dates before the leap second table can be created using TAI or TT, but not viewed in UTC
+        # dates before the leap second table can be created using TAI or TT,
+        # but not viewed in UTC
         earlyDt = DateTime("1960-01-01T00:00:00", DateTime.TAI)
         with self.assertRaises(pexExcept.DomainError):
             earlyDt.toString(DateTime.UTC)
@@ -212,9 +214,11 @@ class DateTimeTestCase(unittest.TestCase):
             DateTime("3200-01-01T00:00:00Z", DateTime.TAI)  # way too late
 
     def testWraparound(self):
-        """Test that a date later than 2038-01-19, 03:14:07 does not wrap around
+        """Test that a date later than 2038-01-19, 03:14:07 does not wrap
+        around.
 
-        This will fail on old versions of unix, and indicates that DateTime is not safe
+        This will fail on old versions of unix, and indicates that DateTime
+        is not safe.
         """
         dateStr = "2040-01-01T00:00:00.000000000"
         self.assertEqual(str(DateTime(dateStr, DateTime.TAI)), "DateTime(\"{}\", TAI)".format(dateStr))


### PR DESCRIPTION
get() now matches the dict.get API except that it always
calls getScalar internally whilst also providing a default
value.

The tests have been modified accordingly and the deprecation
message has been removed.