### PR TITLE
DM-21357: Add value and items methods to PropertySet/List

### DIFF
--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -26,7 +26,7 @@ __all__ = ["getPropertySetState", "getPropertyListState", "setPropertySetState",
 
 import enum
 import numbers
-from collections.abc import Mapping, KeysView
+from collections.abc import Mapping, KeysView, ValuesView, ItemsView
 
 # Ensure that C++ exceptions are properly translated to Python
 import lsst.pex.exceptions  # noqa: F401
@@ -599,6 +599,12 @@ class PropertySet:
 
     def keys(self):
         return KeysView(self)
+
+    def items(self):
+        return ItemsView(self)
+
+    def values(self):
+        return ValuesView(self)
 
     def __reduce__(self):
         # It would be a bit simpler to use __setstate__ and __getstate__.

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -123,6 +123,19 @@ class DictTestCase(unittest.TestCase):
         for k in keys:
             self.assertIn(k, container)
 
+        for k, v in container.items():
+            self.assertIn(k, container)
+            self.assertEqual(v, container[k])
+
+        # Check that string form of the non-PropertySet values are present
+        # when iterating over values.  This is a simple test to ensure
+        # that values() does do something useful
+        values = {str(container[k]) for k in container if not isinstance(container[k],
+                                                                         lsst.daf.base.PropertySet)}
+        for v in container.values():
+            if not isinstance(v, lsst.daf.base.PropertySet):
+                self.assertIn(str(v), values)
+
         # Assign a PropertySet
         ps2 = lsst.daf.base.PropertySet()
         ps2.setString("newstring", "stringValue")
@@ -162,6 +175,10 @@ class DictTestCase(unittest.TestCase):
         self.assertEqual(len(keys), 17)
         for k in keys:
             self.assertIn(k, container)
+
+        for k, v in container.items():
+            self.assertIn(k, container)
+            self.assertEqual(v, container[k])
 
         # Assign a PropertySet
         ps2 = lsst.daf.base.PropertySet()


### PR DESCRIPTION
They were missed by mistake previously since they do not
automatically get implemented because pybind11 classes
can't inherit from collections.abc