### PR TITLE
DM-29117: Allow dict interface to upgrade integer types

### DIFF
--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -227,6 +227,22 @@ def _propertyContainerGet(container, name, returnStyle):
     raise TypeError('Unknown PropertySet value type for ' + name)
 
 
+def _iterable(a):
+    """Make input iterable.
+
+    Takes whatever is given to it and yields it back one element at a time.
+    If it is not an iterable or it is a string or PropertySet/List,
+    yields itself.
+    """
+    if isinstance(a, (str, PropertyList, PropertySet)):
+        yield a
+        return
+    try:
+        yield from a
+    except Exception:
+        yield a
+
+
 def _guessIntegerType(container, name, value):
     """Given an existing container and name, determine the type
     that should be used for the supplied value. The supplied value
@@ -248,7 +264,7 @@ def _guessIntegerType(container, name, value):
         Name of item
 
     value : `object`
-        Value to be assigned a type
+        Value to be assigned a type. Can be an iterable.
 
     Returns
     -------
@@ -256,7 +272,6 @@ def _guessIntegerType(container, name, value):
         Type to use for the supplied value. `None` if the input is
         `bool` or a non-integral value.
     """
-    useType = None
     maxInt = 2147483647
     minInt = -2147483648
     maxLongLong = 2**63 - 1
@@ -264,53 +279,86 @@ def _guessIntegerType(container, name, value):
     maxU64 = 2**64 - 1
     minU64 = 0
 
-    # We do not want to convert bool to int so let the system work that
-    # out itself
-    if isinstance(value, bool):
-        return useType
+    # Go through the values to find the range of supplied integers,
+    # stopping early if we don't have an integer.
+    min = None
+    max = None
+    for v in _iterable(value):
+        # Do not try to convert a bool to an integer
+        if not isinstance(v, numbers.Integral) or isinstance(v, bool):
+            return None
 
-    if isinstance(value, numbers.Integral):
+        if min is None:
+            min = v
+            max = v
+        elif v < min:
+            min = v
+        elif v > max:
+            max = v
 
-        def _choose_int_from_range(int_value, current_type):
-            print(f"Checking in '{name}' for {int_value} ({current_type})")
-            if int_value <= maxInt and int_value >= minInt and current_type in (None, "Int"):
-                # Use Int only if in range and either no current type or the
-                # current type is an Int.
-                use_type = "Int"
-            elif int_value >= minLongLong and int_value < 0:
-                # All large negatives must be LongLong if they did not fit
-                # in Int clause above.
-                use_type = "LongLong"
-            elif int_value >= 0 and int_value <= maxLongLong and current_type in (None, "Int", "LongLong"):
-                # Larger than Int or already a LongLong
-                use_type = "LongLong"
-            elif int_value <= maxU64 and int_value >= minU64:
-                use_type = "UnsignedLongLong"
-            else:
-                raise RuntimeError("Unable to guess integer type for storing out of "
-                                   f"range value: {int_value}")
-            return use_type
+    # Safety net
+    if min is None or max is None:
+        raise RuntimeError(f"Internal logic failure calculating integer range of {value}")
 
-        try:
-            containerType = _propertyContainerElementTypeName(container, name)
-        except LookupError:
-            useType = _choose_int_from_range(value, None)
+    def _choose_int_from_range(int_value, current_type):
+        # If this is changing type from non-integer the current type
+        # does not matter.
+        if current_type not in {"Int", "LongLong", "UnsignedLongLong"}:
+            current_type = None
+
+        if int_value <= maxInt and int_value >= minInt and current_type in (None, "Int"):
+            # Use Int only if in range and either no current type or the
+            # current type is an Int.
+            use_type = "Int"
+        elif int_value >= minLongLong and int_value < 0:
+            # All large negatives must be LongLong if they did not fit
+            # in Int clause above.
+            use_type = "LongLong"
+        elif int_value >= 0 and int_value <= maxLongLong and current_type in (None, "Int", "LongLong"):
+            # Larger than Int or already a LongLong
+            use_type = "LongLong"
+        elif int_value <= maxU64 and int_value >= minU64:
+            use_type = "UnsignedLongLong"
         else:
-            useType = _choose_int_from_range(value, containerType)
+            raise RuntimeError("Unable to guess integer type for storing out of "
+                               f"range value: {int_value}")
+        return use_type
 
-    return useType
+    try:
+        containerType = _propertyContainerElementTypeName(container, name)
+    except LookupError:
+        containerType = None
+
+    useTypeMin = _choose_int_from_range(min, containerType)
+    useTypeMax = _choose_int_from_range(max, containerType)
+
+    if useTypeMin == useTypeMax:
+        return useTypeMin
+
+    # When different the combinations are:
+    # Int + LongLong
+    # Int + UnsignedLongLong
+    # LongLong + UnsignedLongLong
+
+    choices = {useTypeMin, useTypeMax}
+    if choices == {"Int", "LongLong"}:
+        return "LongLong"
+
+    # If UnsignedLongLong is required things will break if the min
+    # is negative. They will break whatever we choose if that is the case
+    # but we have no choice but to return the UnsignedLongLong regardless.
+    if "UnsignedLongLong" in choices:
+        return "UnsignedLongLong"
+
+    raise RuntimeError(f"Logic error in guessing integer type from {min} and {max}")
 
 
 def _propertyContainerSet(container, name, value, typeMenu, *args):
     """Set a single Python value of unknown type
     """
-    if hasattr(value, "__iter__") and not isinstance(value, (str, PropertySet, PropertyList)):
-        exemplar = value[0]
-    else:
-        exemplar = value
-
+    exemplar = next(_iterable(value))
     t = type(exemplar)
-    setType = _guessIntegerType(container, name, exemplar)
+    setType = _guessIntegerType(container, name, value)
 
     if setType is not None or t in typeMenu:
         if setType is None:
@@ -327,11 +375,7 @@ def _propertyContainerSet(container, name, value, typeMenu, *args):
 def _propertyContainerAdd(container, name, value, typeMenu, *args):
     """Add a single Python value of unknown type
     """
-    if hasattr(value, "__iter__"):
-        exemplar = value[0]
-    else:
-        exemplar = value
-
+    exemplar = next(_iterable(value))
     t = type(exemplar)
     addType = _guessIntegerType(container, name, exemplar)
 
@@ -549,7 +593,7 @@ class PropertySet:
 
     def __eq__(self, other):
         if type(self) != type(other):
-            return False
+            return NotImplemented
 
         if len(self) != len(other):
             return False

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -356,7 +356,12 @@ def _guessIntegerType(container, name, value):
 def _propertyContainerSet(container, name, value, typeMenu, *args):
     """Set a single Python value of unknown type
     """
-    exemplar = next(_iterable(value))
+    try:
+        exemplar = next(_iterable(value))
+    except StopIteration:
+        # Do nothing if nothing provided. This matches the behavior
+        # of the explicit setX() methods.
+        return
     t = type(exemplar)
     setType = _guessIntegerType(container, name, value)
 
@@ -375,7 +380,12 @@ def _propertyContainerSet(container, name, value, typeMenu, *args):
 def _propertyContainerAdd(container, name, value, typeMenu, *args):
     """Add a single Python value of unknown type
     """
-    exemplar = next(_iterable(value))
+    try:
+        exemplar = next(_iterable(value))
+    except StopIteration:
+        # Adding an empty iterable to an existing entry is a no-op
+        # since there is nothing to add.
+        return
     t = type(exemplar)
     addType = _guessIntegerType(container, name, exemplar)
 

--- a/tests/test_PropertySet_2.py
+++ b/tests/test_PropertySet_2.py
@@ -173,6 +173,10 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.valueCount(), 7)
         self.checkPickle(ps)
 
+        # Check that an empty list does nothing
+        ps.setInt("empty", [])
+        self.assertNotIn("empty", ps)
+
     def testGetVector2(self):
         ps = dafBase.PropertySet()
         v = [42, 2008, 1]
@@ -204,6 +208,10 @@ class PropertySetTestCase(unittest.TestCase):
         self.assertEqual(ps.getString("other"), "foo")
         self.assertEqual(ps.valueCount(), 6)
         self.checkPickle(ps)
+
+        # Check that an empty list does nothing
+        ps.addInt("ints", [])
+        self.assertEqual(ps.getArrayInt("ints"), w)
 
     def testSetAddVector(self):
         ps = dafBase.PropertySet()

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -226,6 +226,34 @@ class DictTestCase(unittest.TestCase):
         self.assertEqual(container[key], 42)
         self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
 
+        # Check that 0 ends up with the correct type
+        key = "zero"
+        container[key] = 0
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_Int)
+
+        # And again but bouncing through an Undef
+        key = "zeroundef"
+        container[key] = None
+        container[key] = 0
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_Int)
+
+        # Store an array of integers with a large value
+        key = "intarray"
+        testArray = [1, 8589934592, 3]
+        container[key] = testArray
+        self.assertEqual(container.getArray(key), testArray)
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
+
+        container[key] = [-1, 2, 3]
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
+
+        container[key] = [1, 2, 2**63 + 1]
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_UnsignedLongLong)
+
+        with self.assertRaises(TypeError):
+            # This can't fit LongLong but also contains negative number
+            container[key] = [-1, 2, 2**63 + 1]
+
     def testCopyPropertyList(self):
         # For PropertyList shallow copy and deep copy are identical
         shallow = copy.copy(self.pl)

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -250,6 +250,10 @@ class DictTestCase(unittest.TestCase):
         container[key] = [1, 2, 2**63 + 1]
         self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_UnsignedLongLong)
 
+        # Store an empty list
+        container["emptylist"] = []
+        self.assertNotIn("emptylist", container)
+
         with self.assertRaises(TypeError):
             # This can't fit LongLong but also contains negative number
             container[key] = [-1, 2, 2**63 + 1]

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -152,6 +152,22 @@ class DictTestCase(unittest.TestCase):
 
         container["a_property_list"] = self.pl
 
+        # Upgrading of integer
+        key = "upgrade"
+        container[key] = 1
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_Int)
+        self.assertEqual(container[key], 1)
+
+        # Set to 64-bit int value
+        container[key] = 8589934592
+        self.assertEqual(container[key], 8589934592)
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
+
+        # Set to small int again, type should not change
+        container[key] = 42
+        self.assertEqual(container[key], 42)
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
+
     def testDictPropertyList(self):
         container = self.pl
         self.assertIn("string", container)
@@ -195,6 +211,20 @@ class DictTestCase(unittest.TestCase):
         # Dict should be converted to a PropertySet
         container["dict"] = {"a": 1, "b": 2}
         self.assertEqual(container.getScalar("dict.b"), 2)
+
+        # Upgrading of integer
+        key = "upgrade"
+        container[key] = 1
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_Int)
+        self.assertEqual(container[key], 1)
+        container[key] = 8589934592
+        self.assertEqual(container[key], 8589934592)
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
+
+        # Set to small int again, type should not change
+        container[key] = 42
+        self.assertEqual(container[key], 42)
+        self.assertEqual(container.typeOf(key), lsst.daf.base.PropertySet.TYPE_LongLong)
 
     def testCopyPropertyList(self):
         # For PropertyList shallow copy and deep copy are identical


### PR DESCRIPTION
They are not downgraded so an Int64 will stay an Int64 even if assigned "42" but an Int32 will upgrade to an Int64 if needed.