### PR TITLE
DM-32682: Allow del and pop to delete hierarchical names

### DIFF
--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -676,7 +676,8 @@ class PropertySet:
         return self.getScalar(name)
 
     def __delitem__(self, name):
-        if name in self:
+        if self.exists(name):
+            # dot-delimited names should work so cannot use "in".
             self.remove(name)
         else:
             raise KeyError(f"{name} not present in dict")
@@ -706,7 +707,7 @@ class PropertySet:
         Parameters
         ----------
         name : `str`
-            Name of the key to remove.
+            Name of the key to remove. Can be hierarchical.
         default : Any, optional
             Value to return if the key is not present.
 
@@ -720,7 +721,7 @@ class PropertySet:
         KeyError
             Raised if no default is given and the key is missing.
         """
-        if name in self:
+        if self.exists(name):
             value = self[name]
             self.remove(name)
         else:


### PR DESCRIPTION
People use keys of "a.b.c" in `remove()` and we should allow that to work with `del` and `pop()`. This requires we use `exists()` rather than `in` to check whether the key is present or not because `in` only looks at the top level since it has to be consistent with `__iter__`.