### PR TITLE
DM-33519: Clean up shared_ptr usage and nomenclature.

### DIFF
--- a/include/lsst/daf/base/PropertyList.h
+++ b/include/lsst/daf/base/PropertyList.h
@@ -82,9 +82,9 @@ public:
     /**
      * Make a deep copy of the PropertyList and all of its contents.
      *
-     * @return PropertyList::Ptr pointing to the new copy.
+     * @return PropertyList pointing to the new copy.
      */
-    virtual PropertySet::Ptr deepCopy() const;
+    virtual std::shared_ptr<PropertySet> deepCopy() const;
 
     // I can't make copydoc work for this so...
     /**
@@ -156,7 +156,7 @@ public:
      * @param[in] value Value to set.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
      */
-    void set(std::string const& name, PropertySet::Ptr const& value);
+    void set(std::string const& name, std::shared_ptr<PropertySet> const& value);
 
     /// @copydoc PropertySet::set(std::string const&, std::vector<T> const&)
     template <typename T>
@@ -273,12 +273,21 @@ public:
         add(name, value, std::string(comment));
     }
 
+    //@{
     /// @copydoc PropertySet::copy
-    virtual void copy(std::string const& dest, PropertySet::ConstPtr source, std::string const& name,
+    virtual void copy(std::string const& dest, PropertySet const & source, std::string const& name,
                       bool asScalar = false);
+    [[deprecated("Replaced by a non-shared_ptr overload.  Will be removed after v25.")]]
+    virtual void copy(std::string const& dest, std::shared_ptr<PropertySet const> source,
+                      std::string const& name, bool asScalar = false);
+    //@}
 
+    //@{
     /// @copydoc PropertySet::combine
-    virtual void combine(PropertySet::ConstPtr source);
+    virtual void combine(PropertySet const & source);
+    [[deprecated("Replaced by a non-shared_ptr overload.  Will be removed after v25.")]]
+    virtual void combine(std::shared_ptr<PropertySet const> source);
+    //@}
 
     /// @copydoc PropertySet::remove
     virtual void remove(std::string const& name);

--- a/include/lsst/daf/base/PropertyList.h
+++ b/include/lsst/daf/base/PropertyList.h
@@ -155,6 +155,10 @@ public:
      * @param[in] name Property name to set, possibly hierarchical.
      * @param[in] value Value to set.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
+     *
+     * Unlike the base `PropertySet` implementation, `PropertyList` flattens
+     * out nested `PropertySet` objects, storing their keys with nested names
+     * but not the `PropertySet` instance itself.
      */
     void set(std::string const& name, std::shared_ptr<PropertySet> const& value);
 

--- a/include/lsst/daf/base/PropertySet.h
+++ b/include/lsst/daf/base/PropertySet.h
@@ -348,6 +348,12 @@ public:
      * @param[in] name Property name to set, possibly hierarchical.
      * @param[in] value Value to set.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
+     *
+     * If `value` is a `PropertySet`, the default implementation will allow it
+     * to be retreived later via `get` (or other methods) using the given
+     * `name`, and the result will be the same `shared_ptr` passed in, but this
+     * is not guaranteed to be the behavior for all derived classes, which may
+     * flatten out `PropertySet` values instead.
      */
     template <typename T>
     void set(std::string const& name, T const& value);
@@ -380,6 +386,12 @@ public:
      * @param[in] value Value to append.
      * @throws TypeError Type does not match existing values.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
+     *
+     * If `value` is a `PropertySet`, the default implementation will allow it
+     * to be retreived later via `get` (or other methods) using the given
+     * `name`, and the result will be the same `shared_ptr` passed in, but this
+     * is not guaranteed to be the behavior for all derived classes, which may
+     * flatten out `PropertySet` values instead.
      */
     template <typename T>
     void add(std::string const& name, T const& value);

--- a/include/lsst/daf/base/PropertySet.h
+++ b/include/lsst/daf/base/PropertySet.h
@@ -92,9 +92,9 @@ public:
     /**
      * Make a deep copy of the PropertySet and all of its contents.
      *
-     * @return PropertySet::Ptr pointing to the new copy.
+     * @return PropertySet pointing to the new copy.
      */
-    virtual Ptr deepCopy() const;
+    virtual std::shared_ptr<PropertySet> deepCopy() const;
 
     /**
      * Get the number of names in the PropertySet, optionally including those in subproperties.
@@ -143,7 +143,7 @@ public:
      * Determine if a name (possibly hierarchical) is a subproperty.
      *
      * @param[in] name Property name to examine, possibly hierarchical.
-     * @return true if property exists and its values are PropertySet::Ptrs.
+     * @return true if property exists and its values are PropertySet:.
      */
     bool isPropertySetPtr(std::string const& name) const;
 
@@ -312,11 +312,11 @@ public:
      * Get the last value for a subproperty name (possibly hierarchical).
      *
      * @param[in] name Property name to examine, possibly hierarchical.
-     * @return PropertySet::Ptr value.
+     * @return PropertySet value.
      * @throws NotFoundError Property does not exist.
-     * @throws TypeError Value is not a PropertySet::Ptr.
+     * @throws TypeError Value is not a PropertySet.
      */
-    PropertySet::Ptr getAsPropertySetPtr(std::string const& name) const;
+    std::shared_ptr<PropertySet> getAsPropertySetPtr(std::string const& name) const;
 
     /**
      * Get the last value for a Persistable name (possibly hierarchical).
@@ -410,12 +410,13 @@ public:
      */
     void add(std::string const& name, char const* value);
 
+    //@{
     /**
      * Replace a single value vector in the destination with one from the
      * \a source.
      *
      * @param[in] dest Destination property name.
-     * @param[in] source PropertySet::Ptr for the source PropertySet.
+     * @param[in] source PropertySet to extract values from.
      * @param[in] name Property name to extract.
      * @param[in] asScalar If true copy the item as a scalar by ignoring all but the last value
      *                     (which is the value returned by get<T>(name))
@@ -423,9 +424,14 @@ public:
      * @throws InvalidParameterError Name does not exist in source.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
      */
-    virtual void copy(std::string const& dest, ConstPtr source, std::string const& name,
+    virtual void copy(std::string const& dest, PropertySet const & source, std::string const& name,
                       bool asScalar = false);
+    [[deprecated("Replaced by a non-shared_ptr overload.  Will be removed after v25.")]]
+    virtual void copy(std::string const& dest, std::shared_ptr<PropertySet const> source,
+                      std::string const& name, bool asScalar = false);
+    //@}
 
+    //@{
     /**
      * Append all value vectors from the \a source to their corresponding
      * properties.  Sets values if a property does not exist.
@@ -433,13 +439,16 @@ public:
      * If a property already exists then the types of the existing value(s)
      * must match the type of the value(s) in \a source.
      *
-     * @param[in] source PropertySet::Ptr for the source PropertySet.
+     * @param[in] source PropertySet to extract values from.
      * @throws TypeError Type does not match existing values for an item.
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
      *
      * @warning May only partially combine the PropertySets if an exception occurs.
      */
-    virtual void combine(ConstPtr source);
+    virtual void combine(PropertySet const & source);
+    [[deprecated("Replaced by a non-shared_ptr overload.  Will be removed after v25.")]]
+    virtual void combine(std::shared_ptr<PropertySet const> source);
+    //@}
 
     /**
      * Remove all values for a property name (possibly hierarchical).  Does
@@ -503,9 +512,9 @@ private:
      * @throws InvalidParameterError Hierarchical name uses non-PropertySet.
      */
     virtual void _findOrInsert(std::string const& name, std::shared_ptr<std::vector<std::any> > vp);
-    void _cycleCheckPtrVec(std::vector<Ptr> const& v, std::string const& name);
+    void _cycleCheckPtrVec(std::vector<std::shared_ptr<PropertySet>> const& v, std::string const& name);
     void _cycleCheckAnyVec(std::vector<std::any> const& v, std::string const& name);
-    void _cycleCheckPtr(Ptr const& v, std::string const& name);
+    void _cycleCheckPtr(std::shared_ptr<PropertySet> const & v, std::string const& name);
 
     AnyMap _map;
     bool _flat;
@@ -516,9 +525,17 @@ private:
 #endif
 
 template <>
-void PropertySet::add<PropertySet::Ptr>(std::string const& name, Ptr const& value);
+void PropertySet::add<std::shared_ptr<PropertySet>>(
+    std::string const& name,
+    std::shared_ptr<PropertySet> const& value
+);
+
 template <>
-void PropertySet::add<PropertySet::Ptr>(std::string const& name, std::vector<Ptr> const& value);
+void PropertySet::add<std::shared_ptr<PropertySet>>(
+    std::string const& name,
+    std::vector<std::shared_ptr<PropertySet>> const& value
+);
+
 }
 }  // namespace daf
 }  // namespace lsst

--- a/python/lsst/daf/base/propertyContainer/propertySet.cc
+++ b/python/lsst/daf/base/propertyContainer/propertySet.cc
@@ -78,8 +78,14 @@ PYBIND11_MODULE(propertySet, mod) {
                                                   py::const_));
     cls.def("typeOf", &PropertySet::typeOf, py::return_value_policy::reference);
     cls.def("toString", &PropertySet::toString, "topLevelOnly"_a = false, "indent"_a = "");
-    cls.def("copy", &PropertySet::copy, "dest"_a, "source"_a, "name"_a, "asScalar"_a=false);
-    cls.def("combine", &PropertySet::combine);
+    cls.def(
+        "copy",
+        py::overload_cast<std::string const &, PropertySet const &, std::string const &, bool>(
+            &PropertySet::copy
+        ),
+        "dest"_a, "source"_a, "name"_a, "asScalar"_a=false
+    );
+    cls.def("combine", py::overload_cast<PropertySet const &>(&PropertySet::combine));
     cls.def("remove", &PropertySet::remove);
     cls.def("getAsBool", &PropertySet::getAsBool);
     cls.def("getAsInt", &PropertySet::getAsInt);

--- a/tests/test_PropertyList.cc
+++ b/tests/test_PropertyList.cc
@@ -45,16 +45,16 @@ BOOST_AUTO_TEST_SUITE(PropertyListSuite) /* parasoft-suppress LsstDm-3-2a LsstDm
 BOOST_AUTO_TEST_CASE(construct) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                      test harness macros" */
     dafBase::PropertyList pl;
-    dafBase::PropertyList::Ptr plp(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertyList> plp(new dafBase::PropertyList);
     BOOST_CHECK_EQUAL(!plp, false);
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertyList);
     BOOST_CHECK_EQUAL(!psp, false);
 }
 
 BOOST_AUTO_TEST_CASE(bases) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost test
                                  harness macros" */
-    dafBase::PropertyList::Ptr plp(new dafBase::PropertyList);
-    dafBase::PropertySet::Ptr psp = plp;
+    std::shared_ptr<dafBase::PropertyList> plp(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertySet> psp = plp;
     BOOST_CHECK_EQUAL(!plp, false);
 }
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(getScalar) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Ls
 
 BOOST_AUTO_TEST_CASE(getScalarPSP) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                         test harness macros" */
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertyList);
     psp->set("bool", true);
     psp->set("char", '*');
     short s = 42;
@@ -202,14 +202,13 @@ BOOST_AUTO_TEST_CASE(comments) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Lss
 
 BOOST_AUTO_TEST_CASE(deepCopy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                     test harness macros" */
-    dafBase::PropertyList::Ptr plp(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertyList> plp(new dafBase::PropertyList);
     plp->set("int", 31, "test");
     BOOST_CHECK_EQUAL(plp->get<int>("int"), 31);
-    dafBase::PropertySet::Ptr psp = plp;
-    dafBase::PropertySet::Ptr psp2 = psp->deepCopy();
+    std::shared_ptr<dafBase::PropertySet> psp = plp;
+    auto psp2 = psp->deepCopy();
     BOOST_CHECK_EQUAL(psp2->get<int>("int"), 31);
-    dafBase::PropertyList::Ptr plp2 =
-            std::dynamic_pointer_cast<dafBase::PropertyList, dafBase::PropertySet>(psp2);
+    auto plp2 = std::dynamic_pointer_cast<dafBase::PropertyList, dafBase::PropertySet>(psp2);
     BOOST_CHECK_EQUAL(!plp2, false);
     BOOST_CHECK_EQUAL(plp2->get<int>("int"), 31);
     BOOST_CHECK_EQUAL(plp2->getComment("int"), "test");
@@ -377,7 +376,7 @@ BOOST_AUTO_TEST_CASE(getAs) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm
     pl.set<std::string>("char*", "foo");
     pl.set("char*2", "foo2");
     pl.set("string", std::string("bar"));
-    dafBase::PropertySet::Ptr plp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> plp(new dafBase::PropertySet);
     plp->set("bottom", "x");
     pl.set("top", plp);
 
@@ -416,10 +415,10 @@ BOOST_AUTO_TEST_CASE(combineThrow) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a
     dafBase::PropertyList pl;
     pl.set("int", 42);
 
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("int", 3.14159);
 
-    BOOST_CHECK_THROW(pl.combine(psp), pexExcept::TypeError);
+    BOOST_CHECK_THROW(pl.combine(*psp), pexExcept::TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(combineHierarchical) {
@@ -428,7 +427,7 @@ BOOST_AUTO_TEST_CASE(combineHierarchical) {
     dafBase::PropertyList pl;
     pl.set("a.b", 1);
 
-    dafBase::PropertySet::Ptr plp;
+    std::shared_ptr<dafBase::PropertySet> plp;
     BOOST_CHECK_NO_THROW(plp = pl.deepCopy());
 
     BOOST_CHECK_EQUAL(pl.getAsInt("a.b"), plp->getAsInt("a.b"));
@@ -436,16 +435,14 @@ BOOST_AUTO_TEST_CASE(combineHierarchical) {
 
 BOOST_AUTO_TEST_CASE(combineAsPS) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                        test harness macros" */
-    dafBase::PropertyList::Ptr plp1(new dafBase::PropertyList);
-    dafBase::PropertyList::Ptr plp2(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertyList> plp1(new dafBase::PropertyList);
+    std::shared_ptr<dafBase::PropertyList> plp2(new dafBase::PropertyList);
     plp1->set("int", 42, "comment");
     plp2->set("float", 3.14159, "stuff");
-    dafBase::PropertySet::Ptr psp =
-            std::static_pointer_cast<dafBase::PropertySet, dafBase::PropertyList>(plp1);
+    auto psp = std::static_pointer_cast<dafBase::PropertySet, dafBase::PropertyList>(plp1);
     psp.get()->set("foo", 36);
-    psp.get()->combine(plp2);
-    dafBase::PropertyList::Ptr newPlp =
-            std::dynamic_pointer_cast<dafBase::PropertyList, dafBase::PropertySet>(psp);
+    psp.get()->combine(*plp2);
+    auto newPlp = std::dynamic_pointer_cast<dafBase::PropertyList, dafBase::PropertySet>(psp);
     BOOST_CHECK_EQUAL(!newPlp, false);
     BOOST_CHECK_EQUAL(newPlp->get<int>("int"), 42);
     BOOST_CHECK_EQUAL(newPlp->get<int>("foo"), 36);

--- a/tests/test_PropertySet_1.cc
+++ b/tests/test_PropertySet_1.cc
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_SUITE(PropertySetSuite) /* parasoft-suppress LsstDm-3-2a LsstDm-
 BOOST_AUTO_TEST_CASE(construct) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                      test harness macros" */
     dafBase::PropertySet ps;
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     BOOST_CHECK_EQUAL(!psp, false);
 }
 
@@ -305,14 +305,14 @@ BOOST_AUTO_TEST_CASE(arrayProperties) { /* parasoft-suppress LsstDm-3-1 LsstDm-3
 BOOST_AUTO_TEST_CASE(hierarchy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost
                                      test harness macros" */
     dafBase::PropertySet ps;
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
 
     psp->set("pre", 1);
     ps.set("ps1", psp);
     psp->set("post", 2);
     ps.set("int", 42);
-    ps.set("ps2", dafBase::PropertySet::Ptr(new dafBase::PropertySet));
-    ps.get<dafBase::PropertySet::Ptr>("ps2")->set("plus", 10.24);
+    ps.set("ps2", std::shared_ptr<dafBase::PropertySet>(new dafBase::PropertySet));
+    ps.get<std::shared_ptr<dafBase::PropertySet>>("ps2")->set("plus", 10.24);
     ps.set("ps2.minus", -10.24);
     ps.set("ps3.sub1", "foo");
     ps.set("ps3.sub2", "bar");
@@ -338,9 +338,9 @@ BOOST_AUTO_TEST_CASE(hierarchy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Ls
     BOOST_CHECK(!ps.isPropertySetPtr("ps3.sub1"));
     BOOST_CHECK(!ps.isPropertySetPtr("ps3.sub2"));
 
-    dafBase::PropertySet::Ptr psp1 = ps.get<dafBase::PropertySet::Ptr>("ps1");
-    dafBase::PropertySet::Ptr psp2 = ps.get<dafBase::PropertySet::Ptr>("ps2");
-    dafBase::PropertySet::Ptr psp3 = ps.get<dafBase::PropertySet::Ptr>("ps3");
+    auto psp1 = ps.get<std::shared_ptr<dafBase::PropertySet>>("ps1");
+    auto psp2 = ps.get<std::shared_ptr<dafBase::PropertySet>>("ps2");
+    auto psp3 = ps.get<std::shared_ptr<dafBase::PropertySet>>("ps3");
     BOOST_CHECK(psp1);
     BOOST_CHECK(psp2);
     BOOST_CHECK(psp3);
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(getAs) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm
     ps.set<std::string>("char*", "foo");
     ps.set("char*2", "foo2");
     ps.set("string", std::string("bar"));
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("bottom", "x");
     ps.set("top", psp);
 
@@ -540,14 +540,14 @@ BOOST_AUTO_TEST_CASE(
     ps.set("ps2.minus", -10.24);
     ps.set("ps3.sub.subsub", "foo");
 
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("ps1.pre", 3);
     psp->add("ps1.pre", 4);
     psp->set("int", 2008);
     psp->set("ps2.foo", "bar");
     psp->set("ps4.top", "bottom");
 
-    ps.combine(psp);
+    ps.combine(*psp);
 
     BOOST_CHECK(ps.isPropertySetPtr("ps1"));
     BOOST_CHECK(ps.isPropertySetPtr("ps2"));
@@ -584,10 +584,10 @@ BOOST_AUTO_TEST_CASE(combineThrow) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a
     dafBase::PropertySet ps;
     ps.set("int", 42);
 
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("int", 3.14159);
 
-    BOOST_CHECK_THROW(ps.combine(psp), pexExcept::TypeError);
+    BOOST_CHECK_THROW(ps.combine(*psp), pexExcept::TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(copy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost test
@@ -601,14 +601,14 @@ BOOST_AUTO_TEST_CASE(copy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-
     ps.set("ps2.minus", -10.24);
     ps.set("ps3.sub.subsub", "foo");
 
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("ps1.pre", 3);
     psp->add("ps1.pre", 4);
     psp->set("int", 2008);
     psp->set("ps2.foo", "bar");
     psp->set("ps4.top", "bottom");
 
-    ps.copy("ps1", psp, "ps1");
+    ps.copy("ps1", *psp, "ps1");
 
     BOOST_CHECK(ps.isPropertySetPtr("ps1"));
     BOOST_CHECK(!ps.isArray("ps1"));
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE(copy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-
     BOOST_CHECK_EQUAL(v[0], 3);
     BOOST_CHECK_EQUAL(v[1], 4);
 
-    ps.copy("ps5", psp, "ps4");
+    ps.copy("ps5", *psp, "ps4");
 
     BOOST_CHECK(ps.isPropertySetPtr("ps5"));
     BOOST_CHECK(!ps.isArray("ps5"));
@@ -676,11 +676,11 @@ BOOST_AUTO_TEST_CASE(deepCopy) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Lss
                                     test harness macros" */
     dafBase::PropertySet ps;
     ps.set("int", 42);
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("bottom", "x");
     ps.set("top", psp);
 
-    dafBase::PropertySet::Ptr psp2 = ps.deepCopy();
+    auto psp2 = ps.deepCopy();
     BOOST_CHECK(psp2->exists("int"));
     BOOST_CHECK(psp2->exists("top.bottom"));
     BOOST_CHECK_EQUAL(psp2->getAsInt("int"), 42);
@@ -768,13 +768,13 @@ BOOST_AUTO_TEST_CASE(toString) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a Lss
 
 BOOST_AUTO_TEST_CASE(cycle) { /* parasoft-suppress LsstDm-3-1 LsstDm-3-4a LsstDm-5-25 LsstDm-4-6 "Boost test
                                  harness macros" */
-    dafBase::PropertySet::Ptr psp(new dafBase::PropertySet);
+    std::shared_ptr<dafBase::PropertySet> psp(new dafBase::PropertySet);
     psp->set("int", 42);
     psp->set("a.double", 3.14159);
     psp->set("b.c.d", 2008);
-    dafBase::PropertySet::Ptr a = psp->getAsPropertySetPtr("a");
-    dafBase::PropertySet::Ptr b = psp->getAsPropertySetPtr("b");
-    dafBase::PropertySet::Ptr c = psp->getAsPropertySetPtr("b.c");
+    auto a = psp->getAsPropertySetPtr("a");
+    auto b = psp->getAsPropertySetPtr("b");
+    auto c = psp->getAsPropertySetPtr("b.c");
     BOOST_CHECK_THROW(psp->set("t", psp), pexExcept::InvalidParameterError);
     BOOST_CHECK_THROW(psp->set("a.t", psp), pexExcept::InvalidParameterError);
     BOOST_CHECK_THROW(psp->set("a.t", a), pexExcept::InvalidParameterError);


### PR DESCRIPTION
One small known issue here is that the single commit here should have in retrospect been two, but I don't regret it enough to think it's worth the effort to fix it (it's not a trivial reset + stage hunks).