### PR TITLE
DM-42928: Add methods to get and set nested dictionaries consistently.

### DIFF
--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -811,6 +811,13 @@ class PropertySet:
             Possibly-nested mapping, with `str` keys and values that are `int`,
             `float`, `str`, `bool`, or another `dict` with the same key and
             value types.  Will be empty if ``key`` does not exist.
+
+        Raises
+        ------
+        TypeError
+            Raised if the value associated with this key is not a nested
+            dictionary, but does exist.  Note that this behavior is not
+            consistent with `PropertyList` (which returns an empty `dict`).
         """
         if self.exists(key):
             return self.getScalar(key).toDict()

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -803,7 +803,8 @@ class PropertySet:
         Parameters
         ----------
         key : `str`
-            String key associated with the mapping.
+            String key associated with the mapping.  May not have a ``.``
+            character.
 
         Returns
         -------
@@ -833,11 +834,13 @@ class PropertySet:
         Parameters
         ----------
         key : `str`
-            String key associated with the mapping.
+            String key associated with the mapping.  May not have a ``.``
+            character.
         value : `~collections.abc.Mapping`
             Possibly-nested mapping, with `str` keys and values that are `int`,
             `float`, `str`, `bool`, or another `dict` with the same key and
-            value types.
+            value types.   May not have a ``.``
+            character.
         """
         self.set(key, PropertySet.from_mapping(value))
 
@@ -1119,7 +1122,8 @@ class PropertyList:
         Parameters
         ----------
         key : `str`
-            String key associated with the mapping.
+            String key associated with the mapping.  May not have a ``.``
+            character.
 
         Returns
         -------
@@ -1148,10 +1152,11 @@ class PropertyList:
         Parameters
         ----------
         key : `str`
-            String key associated with the mapping.
+            String key associated with the mapping.  May not have a ``.``
+            character.
         value : `~collections.abc.Mapping`
             Possibly-nested mapping, with `str` keys and values that are `int`,
             `float`, `str`, `bool`, or another `dict` with the same key and
-            value types.
+            value types.  Nested keys may not have a ``.`` character.
         """
         self.set(key, PropertySet.from_mapping(value))

--- a/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
+++ b/python/lsst/daf/base/propertyContainer/propertyContainerContinued.py
@@ -812,11 +812,10 @@ class PropertySet:
             `float`, `str`, `bool`, or another `dict` with the same key and
             value types.  Will be empty if ``key`` does not exist.
         """
-        try:
-            value = self.getScalar(key)
-        except KeyError:
+        if self.exists(key):
+            return self.getScalar(key).toDict()
+        else:
             return {}
-        return value.toDict()
 
     def set_dict(self, key: str, value: NestedMetadataDict) -> None:
         """Assign a possibly-hierarchical nested `dict`.

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -284,6 +284,32 @@ class DictTestCase(unittest.TestCase):
         self.assertNotIn("dt", deep)
         self.assertIn("dt", self.pl)
 
+    def test_get_set_dict(self):
+        """Test the get_dict and set_dict methods of both `PropertyList` and
+        `PropertySet`.
+        """
+
+        def check(obj):
+            d1 = {"one": 1, "two": 2.0, "three": True, "four": {"a": 4, "b": "B"}, "five": {}}
+            obj.set_dict("d", d1)
+            obj.set_dict("e", {})
+            d2 = obj.get_dict("d")
+            # Keys with empty-dict values may or may not be round-tripped.
+            self.assertGreaterEqual(d2.keys(), {"one", "two", "three", "four"})
+            self.assertLessEqual(d2.keys(), {"one", "two", "three", "four", "five"})
+            self.assertEqual(d2["one"], d1["one"])
+            self.assertEqual(d2["two"], d1["two"])
+            self.assertEqual(d2["three"], d1["three"])
+            self.assertEqual(d2["four"], d1["four"])
+            self.assertEqual(d2.get("five", {}), d1["five"])
+            # Empty dict may or may not have been added, and retrieving it or
+            # a key that was never added yields an empty dict.
+            self.assertEqual(obj.get_dict("e"), {})
+            self.assertEqual(obj.get_dict("f"), {})
+
+        check(lsst.daf.base.PropertySet())
+        check(lsst.daf.base.PropertyList())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
These conform to a new typing.Protocol being added to lsst.pipe.base.